### PR TITLE
pass any existing http status code through, otherwise default to 500

### DIFF
--- a/templates/js/app.js
+++ b/templates/js/app.js
@@ -37,6 +37,7 @@ app.use(function(req, res, next) {
 // will print stacktrace
 if (app.get('env') === 'development') {
     app.use(function(err, req, res, next) {
+        res.status(err.status || 500);
         res.render('error', {
             message: err.message,
             error: err
@@ -47,6 +48,7 @@ if (app.get('env') === 'development') {
 // production error handler
 // no stacktraces leaked to user
 app.use(function(err, req, res, next) {
+    res.status(err.status || 500);
     res.render('error', {
         message: err.message,
         error: {}


### PR DESCRIPTION
Without this change I find that it always returns 200 on both code generated errors (bad csrf token for example) or even 404 page errors.
