### PR TITLE
update less-middleware usage

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -136,7 +136,7 @@ function createApplicationAt(path) {
     // CSS Engine support
     switch (program.css) {
       case 'less':
-        app = app.replace('{css}', eol + 'app.use(require(\'less-middleware\')({ src: path.join(__dirname, \'public\') }));');
+        app = app.replace('{css}', eol + 'app.use(require(\'less-middleware\')(path.join(__dirname, \'public\')));');
         break;
       case 'stylus':
         app = app.replace('{css}', eol + 'app.use(require(\'stylus\').middleware(path.join(__dirname, \'public\')));');


### PR DESCRIPTION
Fixes the error "Please update your less-middleware usage" on fresh Express install.
