### PR TITLE
Add more descriptive variable name for root path.

### DIFF
--- a/templates/js/app.js
+++ b/templates/js/app.js
@@ -5,7 +5,7 @@ var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 
-var routes = require('./routes/index');
+var index = require('./routes/index');
 var users = require('./routes/users');
 
 var app = express();
@@ -22,7 +22,7 @@ app.use(bodyParser.urlencoded());
 app.use(cookieParser());{css}
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/', routes);
+app.use('/', index);
 app.use('/users', users);
 
 /// catch 404 and forward to error handler


### PR DESCRIPTION
Looking at https://github.com/expressjs/generator/commit/19eb55d4f276c2d51f7d5342725f526080608611, it appears like the previous version had the `routes` variable as a namespace for multiple routers within the same file, i.e. `routes.index`. Since this is not the case anymore, I think `index` could be a better name for the variable and could help avoid confusion.
