### PR TITLE
Using recent version of commander with co-prompt

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var program = require('commander');
+var prompt = require('co-prompt');
 var mkdirp = require('mkdirp');
 var os = require('os');
 var fs = require('fs');
@@ -65,7 +66,7 @@ var www = fs.readFileSync(__dirname + '/../templates/js/www', 'utf-8');
     if (empty || program.force) {
       createApplicationAt(path);
     } else {
-      program.confirm('destination is not empty, continue? ', function(ok){
+      prompt.confirm('destination is not empty, continue? ')(function(err,ok){
         if (ok) {
           process.stdin.destroy();
           createApplicationAt(path);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "repository": "expressjs/generator",
   "license": "MIT",
   "dependencies": {
-    "commander": "1.3.2",
+    "commander": "2.6.0",
+    "co-prompt": "1.0.0",
     "mkdirp": "0.5.0"
   },
   "main": "bin/express",


### PR DESCRIPTION
Not a convincing reason to get stuck with commander v1.3.2, just to use program.confirm().
Upgrade to more recent, stable release of commander and use @tj's [co-prompt](https://github.com/tj/co-prompt).