### PR TITLE
Bumped EJS dependency to ~2.0.0

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -199,7 +199,7 @@ function createApplicationAt(path) {
         pkg.dependencies['jade'] = '~1.8.2';
         break;
       case 'ejs':
-        pkg.dependencies['ejs'] = '~1.0.0';
+        pkg.dependencies['ejs'] = '~2.0.0';
         break;
       case 'hjs':
         pkg.dependencies['hjs'] = '~0.0.6';


### PR DESCRIPTION
Work on v2 is happening here: https://github.com/mde/ejs I'm the new package maintainer.