### PR TITLE
gen: sort dependencies

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -2,6 +2,7 @@
 
 var program = require('commander');
 var mkdirp = require('mkdirp');
+var sortedObject = require('sorted-object');
 var os = require('os');
 var fs = require('fs');
 var path = require('path');
@@ -223,6 +224,8 @@ function createApplicationAt(path) {
         break;
       default:
     }
+
+    pkg.dependencies = sortedObject(pkg.dependencies);
 
     write(path + '/package.json', JSON.stringify(pkg, null, 2));
     write(path + '/app.js', app);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "license": "MIT",
   "dependencies": {
     "commander": "2.6.0",
-    "mkdirp": "0.5.0"
+    "mkdirp": "0.5.0",
+    "sorted-object": "1.0.0"
   },
   "main": "bin/express",
   "preferGlobal": true,


### PR DESCRIPTION
Dependencies in `package.json` will be sorted when a user use npm with `--save`.

So, `package.json` will be like after `npm install --save mocha` is run:

```shell
diff --git a/package.json b/package.json
index ddf6009..8127d63 100644
--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
-    "express": "~4.10.6",
     "body-parser": "~1.10.1",
     "cookie-parser": "~1.3.3",
-    "morgan": "~1.5.1",
-    "serve-favicon": "~2.2.0",
     "debug": "~2.1.1",
-    "jade": "~1.8.2"
+    "express": "~4.10.6",
+    "jade": "~1.8.2",
+    "mocha": "^2.1.0",
+    "morgan": "~1.5.1",
+    "serve-favicon": "~2.2.0"
   }
```

If generator generator the `package.json` with sorted dependencies.
it will be like after `npm install --save mocha` is run:

```shell
diff --git a/package.json b/package.json
index b2c6c18..8d6e23c 100644
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "debug": "~2.1.1",
     "express": "~4.10.6",
     "jade": "~1.8.2",
+    "mocha": "^2.1.0",
     "morgan": "~1.5.1",
     "serve-favicon": "~2.2.0"
   }
```