### PR TITLE
PORT can be named pipe when using iisnode.

### DIFF
--- a/templates/js/www
+++ b/templates/js/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = parseInt(process.env.PORT, 10) || 3000;
+var port = process.env.PORT || 3000;
 app.set('port', port);
 
 /**

--- a/templates/js/www
+++ b/templates/js/www
@@ -58,5 +58,5 @@ function onError(error) {
  */
 
 function onListening() {
-  debug('Listening on port ' + server.address().port);
+  debug('Listening on port ' + (server.address().port || server.address()));
 }


### PR DESCRIPTION
Users running express generator to create apps that run on windows using iisnode have to modify this line in the bin/www file to make the apps work with iisnode because iisnode and node.exe communicate over named pipes. In the iisnode case, the process.env.PORT is a named pipe and not a tcp port. To support this, please accept this pull request.