### PR TITLE
Additional fix for "Make instructions more cmd.exe-friendly"

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -89,7 +89,7 @@ function createApplication(app_name, path) {
     console.log('   run the app:');
 
     if (launchedFromCmd()) {
-      console.log('     %s DEBUG=%s:* & npm start', prompt, app_name);
+      console.log('     %s SET DEBUG=%s:* && npm start', prompt, app_name);
     } else {
       console.log('     %s DEBUG=%s:* npm start', prompt, app_name);
     }


### PR DESCRIPTION
#73 was closed but the fix had a trivial bug.
Add `SET` for environment variables in Windows (and use double `&&` signs for OCD sensitive people...)