### PR TITLE
upgrade hbs

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -212,7 +212,7 @@ function createApplication(app_name, path) {
         pkg.dependencies['hjs'] = '~0.0.6';
         break;
       case 'hbs':
-        pkg.dependencies['hbs'] = '~3.1.0';
+        pkg.dependencies['hbs'] = '~4.0.0';
         break;
       default:
     }


### PR DESCRIPTION
hbs@3 has a bug when parsing **Inline Partials** and **Partial Blocks**,like:
```
{{#> myPartial }}
  Failover content
{{/myPartial}}
```
please update to version 4.0.0,thank you~