### PR TITLE
Add newline to end of package.json

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -238,7 +238,7 @@ function createApplication(app_name, path) {
     pkg.dependencies = sortedObject(pkg.dependencies);
 
     // write files
-    write(path + '/package.json', JSON.stringify(pkg, null, 2));
+    write(path + '/package.json', JSON.stringify(pkg, null, 2) + '\n');
     write(path + '/app.js', app);
     mkdir(path + '/bin', function(){
       www = www.replace('{name}', app_name);


### PR DESCRIPTION
- The file `package.json` is the only generated file that does not end in a newline
- POSIX [defines a line](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206) as terminating in a newline character
- `git diff` will warn when there is no newline at the end of a file
- GitHub shows a red icon at the end of a file when no newline is present
![image](https://cloud.githubusercontent.com/assets/421548/13968893/b46a1af8-f055-11e5-88e0-8f7300c2a004.png)


For these reasons, adding a newline at the end of `package.json` is a trivial fix to a common headache.