### PR TITLE
Release 4.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ node_js:
   - "2.5"
   - "3.3"
   - "4.6"
+  - "5.12"
 sudo: false
 script: "npm run-script test-ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ node_js:
   - "4.6"
   - "5.12"
   - "6.9"
+  - "7.0"
 sudo: false
 script: "npm run-script test-ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
   - "1.8"
   - "2.5"
   - "3.3"
-  - "4.4"
+  - "4.6"
 sudo: false
 script: "npm run-script test-ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,11 @@ node_js:
   - "6.9"
   - "7.0"
 sudo: false
+cache:
+  directories:
+    - node_modules
+before_install:
+  # Update Node.js modules
+  - "test ! -d node_modules || npm prune"
+  - "test ! -d node_modules || npm rebuild"
 script: "npm run-script test-ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ node_js:
   - "3.3"
   - "4.6"
   - "5.12"
+  - "6.9"
 sudo: false
 script: "npm run-script test-ci"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 (The MIT License)
 
 Copyright (c) 2009-2013 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This generator can also be further configured with the following command line fl
         --hbs           add handlebars engine support
         --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
-    -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade|twig|vash) (defaults to jade)
+    -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ npm start
 This generator can also be further configured with the following command line flags.
 
     -h, --help          output usage information
-    -V, --version       output the version number
+        --version       output the version number
     -e, --ejs           add ejs engine support (defaults to jade)
         --hbs           add handlebars engine support
     -H, --hogan         add hogan.js engine support

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The quickest way to get started with express is to utilize the executable `expre
 Create the app:
 
 ```bash
-$ express /tmp/foo && cd /tmp/foo
+$ express --view=hbs /tmp/foo && cd /tmp/foo
 ```
 
 Install dependencies:

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ This generator can also be further configured with the following command line fl
 
     -h, --help          output usage information
         --version       output the version number
-    -e, --ejs           add ejs engine support (defaults to jade)
+    -e, --ejs           add ejs engine support
         --hbs           add handlebars engine support
         --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
+    -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade) (defaults to jade)
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This generator can also be further configured with the following command line fl
         --hbs           add handlebars engine support
         --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
-    -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade) (defaults to jade)
+    -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade|vash) (defaults to jade)
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install dependencies:
 $ npm install
 ```
 
-Rock and Roll
+Start your Express.js app at `http://localhost:3000/`:
 
 ```bash
 $ npm start

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This generator can also be further configured with the following command line fl
         --version       output the version number
     -e, --ejs           add ejs engine support (defaults to jade)
         --hbs           add handlebars engine support
+        --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This generator can also be further configured with the following command line fl
         --hbs           add handlebars engine support
         --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
-    -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade|vash) (defaults to jade)
+    -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade|twig|vash) (defaults to jade)
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     - nodejs_version: "1.8"
     - nodejs_version: "2.5"
     - nodejs_version: "3.3"
-    - nodejs_version: "4.4"
+    - nodejs_version: "4.6"
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - nodejs_version: "2.5"
     - nodejs_version: "3.3"
     - nodejs_version: "4.6"
+    - nodejs_version: "5.12"
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     - nodejs_version: "3.3"
     - nodejs_version: "4.6"
     - nodejs_version: "5.12"
+    - nodejs_version: "6.9"
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - nodejs_version: "4.6"
     - nodejs_version: "5.12"
     - nodejs_version: "6.9"
+    - nodejs_version: "7.0"
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,12 @@ environment:
     - nodejs_version: "5.12"
     - nodejs_version: "6.9"
     - nodejs_version: "7.0"
+cache:
+  - node_modules
 install:
   - ps: Install-Product node $env:nodejs_version
+  - if exist node_modules npm prune
+  - if exist node_modules npm rebuild
   - npm install
 build: off
 test_script:

--- a/bin/express
+++ b/bin/express
@@ -7,6 +7,7 @@ var fs = require('fs');
 var path = require('path');
 var readline = require('readline');
 var sortedObject = require('sorted-object');
+var util = require('util');
 
 var _exit = process.exit;
 var eol = os.EOL;
@@ -44,10 +45,10 @@ before(program, 'unknownOption', function () {
 program
   .version(version, '    --version')
   .usage('[options] [dir]')
-  .option('-e, --ejs', 'add ejs engine support')
-  .option('    --pug', 'add pug engine support')
-  .option('    --hbs', 'add handlebars engine support')
-  .option('-H, --hogan', 'add hogan.js engine support')
+  .option('-e, --ejs', 'add ejs engine support', renamedOption('--ejs', '--view=ejs'))
+  .option('    --pug', 'add pug engine support', renamedOption('--pug', '--view=pug'))
+  .option('    --hbs', 'add handlebars engine support', renamedOption('--hbs', '--view=hbs'))
+  .option('-H, --hogan', 'add hogan.js engine support', renamedOption('--hogan', '--view=hogan'))
   .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
@@ -414,6 +415,20 @@ function main() {
       });
     }
   });
+}
+
+/**
+ * Generate a callback function for commander to warn about renamed option.
+ *
+ * @param {String} originalName
+ * @param {String} newName
+ */
+
+function renamedOption(originalName, newName) {
+  return function (val) {
+    warning(util.format("option `%s' has been renamed to `%s'", originalName, newName))
+    return val
+  }
 }
 
 /**

--- a/bin/express
+++ b/bin/express
@@ -386,11 +386,16 @@ function main() {
 
   // View engine
   if (program.view === undefined) {
-    program.view = 'jade'
     if (program.ejs) program.view = 'ejs'
     if (program.hbs) program.view = 'hbs'
     if (program.hogan) program.view = 'hjs'
     if (program.pug) program.view = 'pug'
+  }
+
+  // Default view engine
+  if (program.view === undefined) {
+    warning("the default view engine will not be jade in future releases\nuse `--view=jade' or `--help' for additional options")
+    program.view = 'jade'
   }
 
   // Generate application
@@ -409,6 +414,20 @@ function main() {
       });
     }
   });
+}
+
+/**
+ * Display a warning similar to how errors are displayed by commander.
+ *
+ * @param {String} message
+ */
+
+function warning(message) {
+  console.error()
+  message.split('\n').forEach(function (line) {
+    console.error('  warning: %s', line)
+  })
+  console.error()
 }
 
 /**

--- a/bin/express
+++ b/bin/express
@@ -25,7 +25,7 @@ before(program, 'outputHelp', function () {
 });
 
 program
-  .version(version)
+  .version(version, '    --version')
   .usage('[options] [dir]')
   .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
   .option('    --hbs', 'add handlebars engine support')

--- a/bin/express
+++ b/bin/express
@@ -48,7 +48,7 @@ program
   .option('    --pug', 'add pug engine support')
   .option('    --hbs', 'add handlebars engine support')
   .option('-H, --hogan', 'add hogan.js engine support')
-  .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade) (defaults to jade)')
+  .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade|vash) (defaults to jade)')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')
@@ -198,6 +198,11 @@ function createApplication(app_name, path) {
           copy_template('pug/layout.pug', path + '/views/layout.pug');
           copy_template('pug/error.pug', path + '/views/error.pug');
           break;
+        case 'vash':
+          copy_template('vash/index.vash', path + '/views/index.vash');
+          copy_template('vash/layout.vash', path + '/views/layout.vash');
+          copy_template('vash/error.vash', path + '/views/error.vash');
+          break;
       }
       complete();
     });
@@ -254,6 +259,9 @@ function createApplication(app_name, path) {
         break;
       case 'pug':
         pkg.dependencies['pug'] = '~2.0.0-beta3';
+        break;
+      case 'vash':
+        pkg.dependencies['vash'] = '~0.12.1';
         break;
       default:
     }

--- a/bin/express
+++ b/bin/express
@@ -20,6 +20,12 @@ process.exit = exit
 
 // CLI
 
+around(program, 'optionMissingArgument', function (fn, args) {
+  program.outputHelp()
+  fn.apply(this, args)
+  return { args: [], unknown: [] }
+})
+
 before(program, 'outputHelp', function () {
   // track if help was shown for unknown option
   this._helpShown = true
@@ -48,6 +54,20 @@ program
 
 if (!exit.exited) {
   main();
+}
+
+/**
+ * Install an around function; AOP.
+ */
+
+function around(obj, method, fn) {
+  var old = obj[method]
+
+  obj[method] = function () {
+    var args = new Array(arguments.length)
+    for (var i = 0; i < args.length; i++) args[i] = arguments[i]
+    return fn.call(this, old, args)
+  }
 }
 
 /**

--- a/bin/express
+++ b/bin/express
@@ -269,7 +269,7 @@ function createApplication(app_name, path) {
         pkg.dependencies['twig'] = '~0.9.5';
         break;
       case 'vash':
-        pkg.dependencies['vash'] = '~0.12.1';
+        pkg.dependencies['vash'] = '~0.12.2';
         break;
       default:
     }

--- a/bin/express
+++ b/bin/express
@@ -231,7 +231,7 @@ function createApplication(app_name, path) {
       , scripts: { start: 'node ./bin/www' }
       , dependencies: {
           'express': '~4.14.0',
-          'body-parser': '~1.15.1',
+          'body-parser': '~1.15.2',
           'cookie-parser': '~1.4.3',
           'debug': '~2.2.0',
           'morgan': '~1.7.0',

--- a/bin/express
+++ b/bin/express
@@ -277,7 +277,7 @@ function createApplication(app_name, path) {
     // CSS Engine support
     switch (program.css) {
       case 'less':
-        pkg.dependencies['less-middleware'] = '1.0.x';
+        pkg.dependencies['less-middleware'] = '~2.2.0';
         break;
       case 'compass':
         pkg.dependencies['node-compass'] = '0.2.3';

--- a/bin/express
+++ b/bin/express
@@ -192,7 +192,7 @@ function createApplication(app_name, path) {
       , private: true
       , scripts: { start: 'node ./bin/www' }
       , dependencies: {
-          'express': '~4.13.4',
+          'express': '~4.14.0',
           'body-parser': '~1.15.1',
           'cookie-parser': '~1.4.3',
           'debug': '~2.2.0',

--- a/bin/express
+++ b/bin/express
@@ -45,6 +45,7 @@ program
   .version(version, '    --version')
   .usage('[options] [dir]')
   .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
+  .option('    --pug', 'add pug engine support')
   .option('    --hbs', 'add handlebars engine support')
   .option('-H, --hogan', 'add hogan.js engine support')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
@@ -191,6 +192,11 @@ function createApplication(app_name, path) {
           copy_template('hbs/layout.hbs', path + '/views/layout.hbs');
           copy_template('hbs/error.hbs', path + '/views/error.hbs');
           break;
+        case 'pug':
+          copy_template('pug/index.pug', path + '/views/index.pug');
+          copy_template('pug/layout.pug', path + '/views/layout.pug');
+          copy_template('pug/error.pug', path + '/views/error.pug');
+          break;
       }
       complete();
     });
@@ -244,6 +250,9 @@ function createApplication(app_name, path) {
         break;
       case 'hbs':
         pkg.dependencies['hbs'] = '~4.0.0';
+        break;
+      case 'pug':
+        pkg.dependencies['pug'] = '~2.0.0-beta3';
         break;
       default:
     }
@@ -363,6 +372,7 @@ function main() {
   if (program.ejs) program.template = 'ejs';
   if (program.hogan) program.template = 'hjs';
   if (program.hbs) program.template = 'hbs';
+  if (program.pug) program.template = 'pug';
 
   // Generate application
   emptyDirectory(destinationPath, function (empty) {

--- a/bin/express
+++ b/bin/express
@@ -44,10 +44,11 @@ before(program, 'unknownOption', function () {
 program
   .version(version, '    --version')
   .usage('[options] [dir]')
-  .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
+  .option('-e, --ejs', 'add ejs engine support')
   .option('    --pug', 'add pug engine support')
   .option('    --hbs', 'add handlebars engine support')
   .option('-H, --hogan', 'add hogan.js engine support')
+  .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade) (defaults to jade)')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')
@@ -173,7 +174,7 @@ function createApplication(app_name, path) {
     });
 
     mkdir(path + '/views', function(){
-      switch (program.template) {
+      switch (program.view) {
         case 'ejs':
           copy_template('ejs/index.ejs', path + '/views/index.ejs');
           copy_template('ejs/error.ejs', path + '/views/error.ejs');
@@ -220,7 +221,7 @@ function createApplication(app_name, path) {
     }
 
     // Template support
-    app = app.replace('{views}', program.template);
+    app = app.replace('{views}', program.view);
 
     // package.json
     var pkg = {
@@ -238,7 +239,7 @@ function createApplication(app_name, path) {
       }
     }
 
-    switch (program.template) {
+    switch (program.view) {
       case 'jade':
         pkg.dependencies['jade'] = '~1.11.0';
         break;
@@ -367,12 +368,14 @@ function main() {
   // App name
   var appName = path.basename(path.resolve(destinationPath));
 
-  // Template engine
-  program.template = 'jade';
-  if (program.ejs) program.template = 'ejs';
-  if (program.hogan) program.template = 'hjs';
-  if (program.hbs) program.template = 'hbs';
-  if (program.pug) program.template = 'pug';
+  // View engine
+  if (program.view === undefined) {
+    program.view = 'jade'
+    if (program.ejs) program.view = 'ejs'
+    if (program.hbs) program.view = 'hbs'
+    if (program.hogan) program.view = 'hjs'
+    if (program.pug) program.view = 'pug'
+  }
 
   // Generate application
   emptyDirectory(destinationPath, function (empty) {

--- a/bin/express
+++ b/bin/express
@@ -48,7 +48,7 @@ program
   .option('    --pug', 'add pug engine support')
   .option('    --hbs', 'add handlebars engine support')
   .option('-H, --hogan', 'add hogan.js engine support')
-  .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade|vash) (defaults to jade)')
+  .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade|twig|vash) (defaults to jade)')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')
@@ -198,6 +198,11 @@ function createApplication(app_name, path) {
           copy_template('pug/layout.pug', path + '/views/layout.pug');
           copy_template('pug/error.pug', path + '/views/error.pug');
           break;
+        case 'twig':
+          copy_template('twig/index.twig', path + '/views/index.twig');
+          copy_template('twig/layout.twig', path + '/views/layout.twig');
+          copy_template('twig/error.twig', path + '/views/error.twig');
+          break;
         case 'vash':
           copy_template('vash/index.vash', path + '/views/index.vash');
           copy_template('vash/layout.vash', path + '/views/layout.vash');
@@ -259,6 +264,9 @@ function createApplication(app_name, path) {
         break;
       case 'pug':
         pkg.dependencies['pug'] = '~2.0.0-beta3';
+        break;
+      case 'twig':
+        pkg.dependencies['twig'] = '~0.9.5';
         break;
       case 'vash':
         pkg.dependencies['vash'] = '~0.12.1';

--- a/bin/express
+++ b/bin/express
@@ -260,7 +260,7 @@ function createApplication(app_name, path) {
         pkg.dependencies['hjs'] = '~0.0.6';
         break;
       case 'hbs':
-        pkg.dependencies['hbs'] = '~4.0.0';
+        pkg.dependencies['hbs'] = '~4.0.1';
         break;
       case 'pug':
         pkg.dependencies['pug'] = '~2.0.0-beta3';

--- a/bin/express
+++ b/bin/express
@@ -48,7 +48,7 @@ program
   .option('    --pug', 'add pug engine support')
   .option('    --hbs', 'add handlebars engine support')
   .option('-H, --hogan', 'add hogan.js engine support')
-  .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade|twig|vash) (defaults to jade)')
+  .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')

--- a/bin/express
+++ b/bin/express
@@ -263,7 +263,7 @@ function createApplication(app_name, path) {
         pkg.dependencies['hbs'] = '~4.0.1';
         break;
       case 'pug':
-        pkg.dependencies['pug'] = '~2.0.0-beta3';
+        pkg.dependencies['pug'] = '~2.0.0-beta6';
         break;
       case 'twig':
         pkg.dependencies['twig'] = '~0.9.5';

--- a/bin/express
+++ b/bin/express
@@ -316,6 +316,18 @@ function copy_template(from, to) {
   from = path.join(__dirname, '..', 'templates', from);
   write(to, fs.readFileSync(from, 'utf-8'));
 }
+/**
+ * Create an app name from a directory path, fitting npm naming requirements.
+ *
+ * @param {String} pathName
+ */
+
+function createAppName(pathName) {
+  return path.basename(pathName)
+    .replace(/[^A-Za-z0-9\.()!~*'-]+/g, '-')
+    .replace(/^[-_\.]+|-+$/g, '')
+    .toLowerCase()
+}
 
 /**
  * Check if the given directory `path` is empty.
@@ -383,7 +395,7 @@ function main() {
   var destinationPath = program.args.shift() || '.';
 
   // App name
-  var appName = path.basename(path.resolve(destinationPath));
+  var appName = createAppName(path.resolve(destinationPath)) || 'hello-world'
 
   // View engine
   if (program.view === undefined) {

--- a/bin/express
+++ b/bin/express
@@ -260,7 +260,7 @@ function createApplication(app_name, path) {
         pkg.dependencies['stylus'] = '0.54.5';
         break;
       case 'sass':
-        pkg.dependencies['node-sass-middleware'] = '0.8.0';
+        pkg.dependencies['node-sass-middleware'] = '0.9.8';
         break;
       default:
     }

--- a/bin/express
+++ b/bin/express
@@ -21,8 +21,19 @@ process.exit = exit
 // CLI
 
 before(program, 'outputHelp', function () {
-  this.allowUnknownOption();
+  // track if help was shown for unknown option
+  this._helpShown = true
 });
+
+before(program, 'unknownOption', function () {
+  // allow unknown options if help was shown, to prevent trailing error
+  this._allowUnknownOption = this._helpShown
+
+  // show help if not yet shown
+  if (!this._helpShown) {
+    program.outputHelp()
+  }
+})
 
 program
   .version(version, '    --version')

--- a/bin/express
+++ b/bin/express
@@ -254,7 +254,7 @@ function createApplication(app_name, path) {
         pkg.dependencies['jade'] = '~1.11.0';
         break;
       case 'ejs':
-        pkg.dependencies['ejs'] = '~2.4.1';
+        pkg.dependencies['ejs'] = '~2.5.2';
         break;
       case 'hjs':
         pkg.dependencies['hjs'] = '~0.0.6';

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "repository": "expressjs/generator",
   "license": "MIT",
   "dependencies": {
-    "commander": "2.7.1",
+    "commander": "2.9.0",
     "mkdirp": "0.5.1",
     "sorted-object": "2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "express": "./bin/express"
   },
   "devDependencies": {
-    "mocha": "2.4.5",
+    "mocha": "2.5.3",
     "rimraf": "2.5.2",
     "supertest": "1.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "devDependencies": {
     "mocha": "2.5.3",
     "rimraf": "2.5.2",
-    "supertest": "1.2.0"
+    "supertest": "1.2.0",
+    "validate-npm-package-name": "2.2.2"
   },
   "engines": {
     "node": ">= 0.10"

--- a/templates/js/app.js
+++ b/templates/js/app.js
@@ -5,7 +5,7 @@ var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 
-var routes = require('./routes/index');
+var index = require('./routes/index');
 var users = require('./routes/users');
 
 var app = express();
@@ -22,7 +22,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());{css}
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/', routes);
+app.use('/', index);
 app.use('/users', users);
 
 // catch 404 and forward to error handler

--- a/templates/js/app.js
+++ b/templates/js/app.js
@@ -32,29 +32,15 @@ app.use(function(req, res, next) {
   next(err);
 });
 
-// error handlers
-
-// development error handler
-// will print stacktrace
-if (app.get('env') === 'development') {
-  app.use(function(err, req, res, next) {
-    res.status(err.status || 500);
-    res.render('error', {
-      message: err.message,
-      error: err
-    });
-  });
-}
-
-// production error handler
-// no stacktraces leaked to user
+// error handler
 app.use(function(err, req, res, next) {
-  res.status(err.status || 500);
-  res.render('error', {
-    message: err.message,
-    error: {}
-  });
-});
+  // set locals, only providing error in development
+  res.locals.message = err.message;
+  res.locals.error = req.app.get('env') === 'development' ? err : {};
 
+  // render the error page
+  res.status(err.status || 500);
+  res.render('error');
+});
 
 module.exports = app;

--- a/templates/pug/error.pug
+++ b/templates/pug/error.pug
@@ -1,0 +1,6 @@
+extends layout
+
+block content
+  h1= message
+  h2= error.status
+  pre #{error.stack}

--- a/templates/pug/index.pug
+++ b/templates/pug/index.pug
@@ -1,0 +1,5 @@
+extends layout
+
+block content
+  h1= title
+  p Welcome to #{title}

--- a/templates/pug/layout.pug
+++ b/templates/pug/layout.pug
@@ -1,0 +1,7 @@
+doctype html
+html
+  head
+    title= title
+    link(rel='stylesheet', href='/stylesheets/style.css')
+  body
+    block content

--- a/templates/twig/error.twig
+++ b/templates/twig/error.twig
@@ -1,0 +1,7 @@
+{% extends 'layout.twig' %}
+
+{% block body %}
+  <h1>{{message}}</h1>
+  <h2>{{error.status}}</h2>
+  <pre>{{error.stack}}</pre>
+{% endblock %}

--- a/templates/twig/index.twig
+++ b/templates/twig/index.twig
@@ -1,0 +1,6 @@
+{% extends 'layout.twig' %}
+
+{% block body %}
+  <h1>{{title}}</h1>
+  <p>Welcome to {{title}}</p>
+{% endblock %}

--- a/templates/twig/layout.twig
+++ b/templates/twig/layout.twig
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title }}</title>
+    <link rel='stylesheet' href='/stylesheets/style.css' />
+  </head>
+  <body>
+    {% block body %}{% endblock %}
+  </body>
+</html>

--- a/templates/vash/error.vash
+++ b/templates/vash/error.vash
@@ -1,0 +1,7 @@
+@html.extend('layout', function(model) {
+  @html.block('content', function(model) {
+    <h1>@model.message</h1>
+    <h2>@model.error.status</h2>
+    <pre>@model.error.stack</pre>
+  })
+})

--- a/templates/vash/index.vash
+++ b/templates/vash/index.vash
@@ -1,0 +1,6 @@
+@html.extend('layout', function(model) {
+  @html.block('content', function(model) {
+    <h1>@model.title</h1>
+    <p>Welcome to @model.title</p>
+  })
+})

--- a/templates/vash/layout.vash
+++ b/templates/vash/layout.vash
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta>
+  <title>@model.title</title>
+  <link rel='stylesheet' href='/stylesheets/style.css' />
+</head>
+<body>
+  @html.block('content')
+</body>
+</html>

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -3,7 +3,6 @@ var assert = require('assert');
 var exec = require('child_process').exec;
 var fs = require('fs');
 var mkdirp = require('mkdirp');
-var mocha = require('mocha');
 var path = require('path');
 var request = require('supertest');
 var rimraf = require('rimraf');
@@ -13,12 +12,12 @@ var binPath = path.resolve(__dirname, '../bin/express');
 var tempDir = path.resolve(__dirname, '../temp');
 
 describe('express(1)', function () {
-  mocha.before(function (done) {
+  before(function (done) {
     this.timeout(30000);
     cleanup(done);
   });
 
-  mocha.after(function (done) {
+  after(function (done) {
     this.timeout(30000);
     cleanup(done);
   });
@@ -28,7 +27,7 @@ describe('express(1)', function () {
     var files;
     var output;
 
-    mocha.before(function (done) {
+    before(function (done) {
       createEnvironment(function (err, newDir) {
         if (err) return done(err);
         dir = newDir;
@@ -36,7 +35,7 @@ describe('express(1)', function () {
       });
     });
 
-    mocha.after(function (done) {
+    after(function (done) {
       this.timeout(30000);
       cleanup(dir, done);
     });
@@ -123,7 +122,7 @@ describe('express(1)', function () {
   describe('(unknown args)', function () {
     var dir;
 
-    mocha.before(function (done) {
+    before(function (done) {
       createEnvironment(function (err, newDir) {
         if (err) return done(err);
         dir = newDir;
@@ -131,7 +130,7 @@ describe('express(1)', function () {
       });
     });
 
-    mocha.after(function (done) {
+    after(function (done) {
       this.timeout(30000);
       cleanup(dir, done);
     });
@@ -168,7 +167,7 @@ describe('express(1)', function () {
     describe('(no engine)', function () {
       var dir;
 
-      mocha.before(function (done) {
+      before(function (done) {
         createEnvironment(function (err, newDir) {
           if (err) return done(err);
           dir = newDir;
@@ -176,7 +175,7 @@ describe('express(1)', function () {
         });
       });
 
-      mocha.after(function (done) {
+      after(function (done) {
         this.timeout(30000);
         cleanup(dir, done);
       });
@@ -212,7 +211,7 @@ describe('express(1)', function () {
       var dir;
       var files;
 
-      mocha.before(function (done) {
+      before(function (done) {
         createEnvironment(function (err, newDir) {
           if (err) return done(err);
           dir = newDir;
@@ -220,7 +219,7 @@ describe('express(1)', function () {
         });
       });
 
-      mocha.after(function (done) {
+      after(function (done) {
         this.timeout(30000);
         cleanup(dir, done);
       });
@@ -279,7 +278,7 @@ describe('express(1)', function () {
       var dir;
       var files;
 
-      mocha.before(function (done) {
+      before(function (done) {
         createEnvironment(function (err, newDir) {
           if (err) return done(err);
           dir = newDir;
@@ -287,7 +286,7 @@ describe('express(1)', function () {
         });
       });
 
-      mocha.after(function (done) {
+      after(function (done) {
         this.timeout(30000);
         cleanup(dir, done);
       });
@@ -347,7 +346,7 @@ describe('express(1)', function () {
     var dir;
     var files;
 
-    mocha.before(function (done) {
+    before(function (done) {
       createEnvironment(function (err, newDir) {
         if (err) return done(err);
         dir = newDir;
@@ -355,7 +354,7 @@ describe('express(1)', function () {
       });
     });
 
-    mocha.after(function (done) {
+    after(function (done) {
       this.timeout(30000);
       cleanup(dir, done);
     });
@@ -415,7 +414,7 @@ describe('express(1)', function () {
     var dir;
     var files;
 
-    mocha.before(function (done) {
+    before(function (done) {
       createEnvironment(function (err, newDir) {
         if (err) return done(err);
         dir = newDir;
@@ -423,7 +422,7 @@ describe('express(1)', function () {
       });
     });
 
-    mocha.after(function (done) {
+    after(function (done) {
       this.timeout(30000);
       cleanup(dir, done);
     });
@@ -457,7 +456,7 @@ describe('express(1)', function () {
   describe('-h', function () {
     var dir;
 
-    mocha.before(function (done) {
+    before(function (done) {
       createEnvironment(function (err, newDir) {
         if (err) return done(err);
         dir = newDir;
@@ -465,7 +464,7 @@ describe('express(1)', function () {
       });
     });
 
-    mocha.after(function (done) {
+    after(function (done) {
       this.timeout(30000);
       cleanup(dir, done);
     });
@@ -487,7 +486,7 @@ describe('express(1)', function () {
     var dir;
     var files;
 
-    mocha.before(function (done) {
+    before(function (done) {
       createEnvironment(function (err, newDir) {
         if (err) return done(err);
         dir = newDir;
@@ -495,7 +494,7 @@ describe('express(1)', function () {
       });
     });
 
-    mocha.after(function (done) {
+    after(function (done) {
       this.timeout(30000);
       cleanup(dir, done);
     });
@@ -562,7 +561,7 @@ describe('express(1)', function () {
   describe('--help', function () {
     var dir;
 
-    mocha.before(function (done) {
+    before(function (done) {
       createEnvironment(function (err, newDir) {
         if (err) return done(err);
         dir = newDir;
@@ -570,7 +569,7 @@ describe('express(1)', function () {
       });
     });
 
-    mocha.after(function (done) {
+    after(function (done) {
       this.timeout(30000);
       cleanup(dir, done);
     });

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -81,7 +81,7 @@ describe('express(1)', function () {
         + '    "body-parser": "~1.15.1",\n'
         + '    "cookie-parser": "~1.4.3",\n'
         + '    "debug": "~2.2.0",\n'
-        + '    "express": "~4.13.4",\n'
+        + '    "express": "~4.14.0",\n'
         + '    "jade": "~1.11.0",\n'
         + '    "morgan": "~1.7.0",\n'
         + '    "serve-favicon": "~2.3.0"\n'

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -449,6 +449,70 @@ describe('express(1)', function () {
       });
     });
   });
+
+  describe('--hogan', function () {
+    var ctx = setupTestEnvironment(this.fullTitle())
+
+    it('should create basic app with hogan templates', function (done) {
+      run(ctx.dir, ['--hogan'], function (err, stdout) {
+        if (err) return done(err)
+        ctx.files = parseCreatedFiles(stdout, ctx.dir)
+        assert.equal(ctx.files.length, 16)
+        done()
+      })
+    })
+
+    it('should have basic files', function () {
+      assert.notEqual(ctx.files.indexOf('bin/www'), -1)
+      assert.notEqual(ctx.files.indexOf('app.js'), -1)
+      assert.notEqual(ctx.files.indexOf('package.json'), -1)
+    })
+
+    it('should have hjs in package dependencies', function () {
+      var file = path.resolve(ctx.dir, 'package.json')
+      var contents = fs.readFileSync(file, 'utf8')
+      var dependencies = JSON.parse(contents).dependencies
+      assert.ok(typeof dependencies.hjs === 'string')
+    })
+
+    it('should have hjs templates', function () {
+      assert.notEqual(ctx.files.indexOf('views/error.hjs'), -1)
+      assert.notEqual(ctx.files.indexOf('views/index.hjs'), -1)
+    })
+
+    it('should have installable dependencies', function (done) {
+      this.timeout(30000)
+      npmInstall(ctx.dir, done)
+    })
+
+    it('should export an express app from app.js', function () {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+      assert.equal(typeof app, 'function')
+      assert.equal(typeof app.handle, 'function')
+    })
+
+    it('should respond to HTTP request', function (done) {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+
+      // the "hjs" module has a global leak
+      this.runnable().globals('renderPartials')
+
+      request(app)
+      .get('/')
+      .expect(200, /<title>Express<\/title>/, done)
+    })
+
+    it('should generate a 404', function (done) {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+
+      request(app)
+      .get('/does_not_exist')
+      .expect(404, /<h1>Not Found<\/h1>/, done)
+    })
+  })
 });
 
 function cleanup(dir, callback) {

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -726,6 +726,68 @@ describe('express(1)', function () {
       })
     })
 
+    describe('twig', function () {
+      var ctx = setupTestEnvironment(this.fullTitle())
+
+      it('should create basic app with twig templates', function (done) {
+        run(ctx.dir, ['--view', 'twig'], function (err, stdout) {
+          if (err) return done(err)
+          ctx.files = parseCreatedFiles(stdout, ctx.dir)
+          assert.equal(ctx.files.length, 17)
+          done()
+        })
+      })
+
+      it('should have basic files', function () {
+        assert.notEqual(ctx.files.indexOf('bin/www'), -1)
+        assert.notEqual(ctx.files.indexOf('app.js'), -1)
+        assert.notEqual(ctx.files.indexOf('package.json'), -1)
+      })
+
+      it('should have twig in package dependencies', function () {
+        var file = path.resolve(ctx.dir, 'package.json')
+        var contents = fs.readFileSync(file, 'utf8')
+        var dependencies = JSON.parse(contents).dependencies
+        assert.ok(typeof dependencies.twig === 'string')
+      })
+
+      it('should have twig templates', function () {
+        assert.notEqual(ctx.files.indexOf('views/error.twig'), -1)
+        assert.notEqual(ctx.files.indexOf('views/index.twig'), -1)
+        assert.notEqual(ctx.files.indexOf('views/layout.twig'), -1)
+      })
+
+      it('should have installable dependencies', function (done) {
+        this.timeout(30000)
+        npmInstall(ctx.dir, done)
+      })
+
+      it('should export an express app from app.js', function () {
+        var file = path.resolve(ctx.dir, 'app.js')
+        var app = require(file)
+        assert.equal(typeof app, 'function')
+        assert.equal(typeof app.handle, 'function')
+      })
+
+      it('should respond to HTTP request', function (done) {
+        var file = path.resolve(ctx.dir, 'app.js')
+        var app = require(file)
+
+        request(app)
+        .get('/')
+        .expect(200, /<title>Express<\/title>/, done)
+      })
+
+      it('should generate a 404', function (done) {
+        var file = path.resolve(ctx.dir, 'app.js')
+        var app = require(file)
+
+        request(app)
+        .get('/does_not_exist')
+        .expect(404, /<h1>Not Found<\/h1>/, done)
+      })
+    })
+
     describe('vash', function () {
       var ctx = setupTestEnvironment(this.fullTitle())
 

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -513,6 +513,68 @@ describe('express(1)', function () {
       .expect(404, /<h1>Not Found<\/h1>/, done)
     })
   })
+
+  describe('--pug', function () {
+    var ctx = setupTestEnvironment(this.fullTitle())
+
+    it('should create basic app with pug templates', function (done) {
+      run(ctx.dir, ['--pug'], function (err, stdout) {
+        if (err) return done(err)
+        ctx.files = parseCreatedFiles(stdout, ctx.dir)
+        assert.equal(ctx.files.length, 17)
+        done()
+      })
+    })
+
+    it('should have basic files', function () {
+      assert.notEqual(ctx.files.indexOf('bin/www'), -1)
+      assert.notEqual(ctx.files.indexOf('app.js'), -1)
+      assert.notEqual(ctx.files.indexOf('package.json'), -1)
+    })
+
+    it('should have pug in package dependencies', function () {
+      var file = path.resolve(ctx.dir, 'package.json')
+      var contents = fs.readFileSync(file, 'utf8')
+      var dependencies = JSON.parse(contents).dependencies
+      assert.ok(typeof dependencies.pug === 'string')
+    })
+
+    it('should have pug templates', function () {
+      assert.notEqual(ctx.files.indexOf('views/error.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/index.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/layout.pug'), -1)
+    })
+
+    it('should have installable dependencies', function (done) {
+      this.timeout(30000)
+      npmInstall(ctx.dir, done)
+    })
+
+    it('should export an express app from app.js', function () {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+      assert.equal(typeof app, 'function')
+      assert.equal(typeof app.handle, 'function')
+    })
+
+    it('should respond to HTTP request', function (done) {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+
+      request(app)
+      .get('/')
+      .expect(200, /<title>Express<\/title>/, done)
+    })
+
+    it('should generate a 404', function (done) {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+
+      request(app)
+      .get('/does_not_exist')
+      .expect(404, /<h1>Not Found<\/h1>/, done)
+    })
+  })
 });
 
 function cleanup(dir, callback) {

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -62,7 +62,7 @@ describe('express(1)', function () {
         + '    "start": "node ./bin/www"\n'
         + '  },\n'
         + '  "dependencies": {\n'
-        + '    "body-parser": "~1.15.1",\n'
+        + '    "body-parser": "~1.15.2",\n'
         + '    "cookie-parser": "~1.4.3",\n'
         + '    "debug": "~2.2.0",\n'
         + '    "express": "~4.14.0",\n'

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -725,6 +725,68 @@ describe('express(1)', function () {
         .expect(404, /<h1>Not Found<\/h1>/, done)
       })
     })
+
+    describe('vash', function () {
+      var ctx = setupTestEnvironment(this.fullTitle())
+
+      it('should create basic app with vash templates', function (done) {
+        run(ctx.dir, ['--view', 'vash'], function (err, stdout) {
+          if (err) return done(err)
+          ctx.files = parseCreatedFiles(stdout, ctx.dir)
+          assert.equal(ctx.files.length, 17)
+          done()
+        })
+      })
+
+      it('should have basic files', function () {
+        assert.notEqual(ctx.files.indexOf('bin/www'), -1)
+        assert.notEqual(ctx.files.indexOf('app.js'), -1)
+        assert.notEqual(ctx.files.indexOf('package.json'), -1)
+      })
+
+      it('should have vash in package dependencies', function () {
+        var file = path.resolve(ctx.dir, 'package.json')
+        var contents = fs.readFileSync(file, 'utf8')
+        var dependencies = JSON.parse(contents).dependencies
+        assert.ok(typeof dependencies.vash === 'string')
+      })
+
+      it('should have vash templates', function () {
+        assert.notEqual(ctx.files.indexOf('views/error.vash'), -1)
+        assert.notEqual(ctx.files.indexOf('views/index.vash'), -1)
+        assert.notEqual(ctx.files.indexOf('views/layout.vash'), -1)
+      })
+
+      it('should have installable dependencies', function (done) {
+        this.timeout(30000)
+        npmInstall(ctx.dir, done)
+      })
+
+      it('should export an express app from app.js', function () {
+        var file = path.resolve(ctx.dir, 'app.js')
+        var app = require(file)
+        assert.equal(typeof app, 'function')
+        assert.equal(typeof app.handle, 'function')
+      })
+
+      it('should respond to HTTP request', function (done) {
+        var file = path.resolve(ctx.dir, 'app.js')
+        var app = require(file)
+
+        request(app)
+        .get('/')
+        .expect(200, /<title>Express<\/title>/, done)
+      })
+
+      it('should generate a 404', function (done) {
+        var file = path.resolve(ctx.dir, 'app.js')
+        var app = require(file)
+
+        request(app)
+        .get('/does_not_exist')
+        .expect(404, /<h1>Not Found<\/h1>/, done)
+      })
+    })
   })
 });
 

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -165,6 +165,49 @@ describe('express(1)', function () {
   });
 
   describe('--css <engine>', function () {
+    describe('(no engine)', function () {
+      var dir;
+
+      mocha.before(function (done) {
+        createEnvironment(function (err, newDir) {
+          if (err) return done(err);
+          dir = newDir;
+          done();
+        });
+      });
+
+      mocha.after(function (done) {
+        this.timeout(30000);
+        cleanup(dir, done);
+      });
+
+      it('should exit with code 1', function (done) {
+        runRaw(dir, ['--css'], function (err, code, stdout, stderr) {
+          if (err) return done(err);
+          assert.strictEqual(code, 1);
+          done();
+        });
+      });
+
+      it('should print usage', function (done) {
+        runRaw(dir, ['--css'], function (err, code, stdout) {
+          if (err) return done(err);
+          assert.ok(/Usage: express/.test(stdout));
+          assert.ok(/--help/.test(stdout));
+          assert.ok(/--version/.test(stdout));
+          done();
+        });
+      });
+
+      it('should print argument missing', function (done) {
+        runRaw(dir, ['--css'], function (err, code, stdout, stderr) {
+          if (err) return done(err);
+          assert.ok(/error: option .* argument missing/.test(stderr));
+          done();
+        });
+      });
+    });
+
     describe('less', function () {
       var dir;
       var files;


### PR DESCRIPTION
This is a tracking issue for release 4.14.

**Please keep feature requests in their own issues**

If you want to make a comment on a particular change, please make the comment in the "Files changed" tab so comments are not lost during a rebase.

List of changes for release:
- [x] Add `pug` as a view engine #107 #109 #110 #113 #114 #115 #116 #118
- [x] Add `twig` as a view engine #100 #122
- [x] Add `vash` as a view engine #124
- [x] Add warning when using the default view engine #141
- [x] Create valid package name #143
- [x] Move view choices under a `--view` option #44 #92 #120 #128
- [x] Provide help/usage when `--css` missing `<engine>`
- [x] Remove `-V` as an alias to `--version`
- [x] Rename variable holding main router #131
- [x] Show help/usage when given an unknown option
- [x] Simplify the default error handler #70

**Testing this release**

If you want to try out this release, you can install it with the following commands:
```bash
$ npm cache clean express-generator
$ npm install expressjs/generator#4.14
```

Owners/collaborators: please do not merge this PR :)