### PR TITLE
Add nunjucks engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This generator can also be further configured with the following command line fl
     -e, --ejs           add ejs engine support (defaults to jade)
         --hbs           add handlebars engine support
     -H, --hogan         add hogan.js engine support
+    -n, --nunjucks      add nunjucks engine support
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory

--- a/bin/express
+++ b/bin/express
@@ -30,6 +30,7 @@ program
   .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
   .option('    --hbs', 'add handlebars engine support')
   .option('-H, --hogan', 'add hogan.js engine support')
+  .option('-n, --nunjucks', 'add nunjucks engine support')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')
@@ -160,6 +161,11 @@ function createApplication(app_name, path) {
           copy_template('hbs/layout.hbs', path + '/views/layout.hbs');
           copy_template('hbs/error.hbs', path + '/views/error.hbs');
           break;
+        case 'nunjucks':
+          copy_template('nunjucks/index.nunjucks', path + '/views/index.nunjucks');
+          copy_template('nunjucks/layout.nunjucks', path + '/views/layout.nunjucks');
+          copy_template('nunjucks/error.nunjucks', path + '/views/error.nunjucks');
+          break;
       }
       complete();
     });
@@ -184,6 +190,16 @@ function createApplication(app_name, path) {
 
     // Template support
     app = app.replace('{views}', program.template);
+
+    // nunjucks configuration
+    if (program.template === 'nunjucks') {
+      app = app.replace('{nunjucks_require}', 'var nunjucks = require(\'nunjucks\')');
+      app = app.replace('{nunjucks_configure}', 'nunjucks.configure(\'views\', {\n  autoescape: true,\n  express: app\n});');
+    }
+    else {
+      app = app.replace('\n{nunjucks_require}', '');
+      app = app.replace('\n\n{nunjucks_configure}', '');
+    }
 
     // package.json
     var pkg = {
@@ -213,6 +229,9 @@ function createApplication(app_name, path) {
         break;
       case 'hbs':
         pkg.dependencies['hbs'] = '~3.1.0';
+        break;
+      case 'nunjucks':
+        pkg.dependencies['nunjucks'] = '~2.3.0';
         break;
       default:
     }
@@ -332,6 +351,7 @@ function main() {
   if (program.ejs) program.template = 'ejs';
   if (program.hogan) program.template = 'hjs';
   if (program.hbs) program.template = 'hbs';
+  if (program.nunjucks) program.template = 'nunjucks';
 
   // Generate application
   emptyDirectory(destinationPath, function (empty) {

--- a/bin/express
+++ b/bin/express
@@ -231,7 +231,7 @@ function createApplication(app_name, path) {
         pkg.dependencies['hbs'] = '~4.0.0';
         break;
       case 'nunjucks':
-        pkg.dependencies['nunjucks'] = '~2.3.0';
+        pkg.dependencies['nunjucks'] = '~2.4.2';
         break;
       default:
     }

--- a/templates/js/app.js
+++ b/templates/js/app.js
@@ -4,6 +4,7 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
+{nunjucks_require}
 
 var routes = require('./routes/index');
 var users = require('./routes/users');
@@ -13,6 +14,8 @@ var app = express();
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', '{views}');
+
+{nunjucks_configure}
 
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));

--- a/templates/nunjucks/error.nunjucks
+++ b/templates/nunjucks/error.nunjucks
@@ -1,0 +1,3 @@
+<h1>{{message}}</h1>
+<h2>{{error.status}}</h2>
+<pre>{{error.stack}}</pre>

--- a/templates/nunjucks/index.nunjucks
+++ b/templates/nunjucks/index.nunjucks
@@ -1,0 +1,6 @@
+{% extends "layout.nunjucks" %}
+
+{% block index %}
+  <h1>{{title}}</h1>
+  <p>Welcome to {{title}}</p>
+{% endblock %}

--- a/templates/nunjucks/layout.nunjucks
+++ b/templates/nunjucks/layout.nunjucks
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{title}}</title>
+    <link rel='stylesheet' href='/stylesheets/style.css' />
+  </head>
+  <body>
+    {% block index %}
+    {% endblock %}
+  </body>
+</html>


### PR DESCRIPTION
You can find more details about **nunjucks** from [here](https://mozilla.github.io/nunjucks/), [here](https://github.com/mozilla/nunjucks) and [here](https://www.npmjs.com/package/nunjucks).

It's just another template engine which has couple of good features. 

I needed to touch app.js to call nunjucks' _configure_ method, and you can see the reason [here](https://mozilla.github.io/nunjucks/getting-started.html). 

There was no test for EJS or Hogan.js, so I also didn't add any test. But if necessary, I can update this PR and add tests as well.

Closes #87 

P.S: Since no-one can open pr 103, I updated the nunjucks version and created this pr.