### PR TITLE
Adds support for dust template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This generator can also be further configured with the following command line fl
     -e, --ejs           add ejs engine support (defaults to jade)
         --hbs           add handlebars engine support
     -H, --hogan         add hogan.js engine support
+    -d, --dust          add dust.js engine support
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory

--- a/bin/express
+++ b/bin/express
@@ -30,6 +30,7 @@ program
   .option('-e, --ejs', 'add ejs engine support (defaults to jade)')
   .option('    --hbs', 'add handlebars engine support')
   .option('-H, --hogan', 'add hogan.js engine support')
+  .option('-d, --dust', 'add dust.js engine support')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')
@@ -160,6 +161,10 @@ function createApplication(app_name, path) {
           copy_template('hbs/layout.hbs', path + '/views/layout.hbs');
           copy_template('hbs/error.hbs', path + '/views/error.hbs');
           break;
+        case 'dust':
+          copy_template('dust/index.dust', path + '/views/index.dust');
+          copy_template('dust/error.dust', path + '/views/error.dust');
+          break;
       }
       complete();
     });
@@ -184,6 +189,16 @@ function createApplication(app_name, path) {
 
     // Template support
     app = app.replace('{views}', program.template);
+
+    // Conditionally add dust.js template code
+    if (program.template === 'dust') {
+      app = app.replace('{adaro}', eol + "var adaro = require('adaro');");
+      app = app.replace('{dust}', eol + "app.engine('dust', adaro.dust());");
+    }
+    else {
+      app = app.replace('{adaro}', '');
+      app = app.replace('{dust}', '');
+    }
 
     // package.json
     var pkg = {
@@ -213,6 +228,9 @@ function createApplication(app_name, path) {
         break;
       case 'hbs':
         pkg.dependencies['hbs'] = '~3.1.0';
+        break;
+      case 'dust':
+        pkg.dependencies['adaro'] = '~1.0.4';
         break;
       default:
     }
@@ -332,6 +350,7 @@ function main() {
   if (program.ejs) program.template = 'ejs';
   if (program.hogan) program.template = 'hjs';
   if (program.hbs) program.template = 'hbs';
+  if (program.dust) program.template = 'dust';
 
   // Generate application
   emptyDirectory(destinationPath, function (empty) {

--- a/templates/dust/error.dust
+++ b/templates/dust/error.dust
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{title}</title>
+    <link rel='stylesheet' href='/stylesheets/style.css' />
+  </head>
+  <body>
+	<h1>{message}</h1>
+	<h2>{error.status}</h2>
+	<pre>{error.stack}</pre>
+  </body>
+</html>

--- a/templates/dust/index.dust
+++ b/templates/dust/index.dust
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{title}</title>
+    <link rel='stylesheet' href='/stylesheets/style.css' />
+  </head>
+  <body>
+    <h1>{title}</h1>
+    <p>Welcome to {title}</p>
+  </body>
+</html>

--- a/templates/js/app.js
+++ b/templates/js/app.js
@@ -3,14 +3,14 @@ var path = require('path');
 var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
-var bodyParser = require('body-parser');
+var bodyParser = require('body-parser');{adaro}
 
 var routes = require('./routes/index');
 var users = require('./routes/users');
 
 var app = express();
 
-// view engine setup
+// view engine setup{dust}
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', '{views}');
 


### PR DESCRIPTION
This PR adds support for dust template engine https://github.com/expressjs/generator/issues/90.

The implementation is a little different from other template engines due to the fact that we have to use [`dustjs-linkedin`](https://www.npmjs.com/package/dustjs-linkedin), instead of `dust` (abandoned) or `dustjs`.

`dustjs-linkedin` does not provide a `__express()`-like method for rendering the templates, so we have to use a wrapper module, [`adaro`](https://www.npmjs.com/package/adaro).
