### PR TITLE
Updates the Express version to ~4.14.0

### DIFF
--- a/bin/express
+++ b/bin/express
@@ -192,7 +192,7 @@ function createApplication(app_name, path) {
       , private: true
       , scripts: { start: 'node ./bin/www' }
       , dependencies: {
-          'express': '~4.13.4',
+          'express': '~4.14.0',
           'body-parser': '~1.15.1',
           'cookie-parser': '~1.4.3',
           'debug': '~2.2.0',

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -81,7 +81,7 @@ describe('express(1)', function () {
         + '    "body-parser": "~1.15.1",\n'
         + '    "cookie-parser": "~1.4.3",\n'
         + '    "debug": "~2.2.0",\n'
-        + '    "express": "~4.13.4",\n'
+        + '    "express": "~4.14.0",\n'
         + '    "jade": "~1.11.0",\n'
         + '    "morgan": "~1.7.0",\n'
         + '    "serve-favicon": "~2.3.0"\n'


### PR DESCRIPTION
# What does this PR do:
Updates the `express` dependency to version `4.14.0`, to tackle this issue:

<img width="1602" alt="screen shot 2016-10-06 at 20 41 23" src="https://cloud.githubusercontent.com/assets/1002056/19171918/2297d4ae-8c17-11e6-8036-0dd20adcc54b.png">
