### PR TITLE
#152: Add option for no view engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This generator can also be further configured with the following command line fl
         --pug           add pug engine support
     -H, --hogan         add hogan.js engine support
     -v, --view <engine> add view <engine> support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
+        --no-view       use HTML directly instead of a view engine
     -c, --css <engine>  add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git           add .gitignore
     -f, --force         force on non-empty directory

--- a/bin/express
+++ b/bin/express
@@ -81,14 +81,14 @@ function addIndexServing(app, viewEngine) {
 function addViewEngine(app, viewEngine) {
   if (program.view == 'none') {
     app.locals.viewEngineSetUp = '';
-    app.locals.renderError = "res.sendFile('error.html', {\n" +
-      "    root: __dirname + '/public/'\n" +
+    app.locals.renderError = "res.sendFile('error.html', {" + eol + 
+      "    root: __dirname + '/public/'" + eol + 
       "  });";
   } else {
-    app.locals.viewEngineSetUp = "\n" +
-      "// view engine setup\n" +
-      "app.set('views', path.join(__dirname, 'views'));\n" +
-      "app.set('view engine', '" + viewEngine + "');\n";
+    app.locals.viewEngineSetUp = eol +
+      "// view engine setup" + eol +
+      "app.set('views', path.join(__dirname, 'views'));" + eol +
+      "app.set('view engine', '" + viewEngine + "');" + eol;
     app.locals.renderError = "res.render('error');";
   }
 }
@@ -264,7 +264,13 @@ function createApplication(app_name, path) {
         app.locals.css = eol + 'app.use(require(\'node-compass\')({mode: \'expanded\'}));'
         break;
       case 'sass':
-        app.locals.css = eol + 'app.use(require(\'node-sass-middleware\')({\n  src: path.join(__dirname, \'public\'),\n  dest: path.join(__dirname, \'public\'),\n  indentedSyntax: true,\n  sourceMap: true\n}));'
+        app.locals.css = eol + 
+          'app.use(require(\'node-sass-middleware\')({' + eol + 
+          '  src: path.join(__dirname, \'public\'),' + eol + 
+          '  dest: path.join(__dirname, \'public\'),' + eol + 
+          '  indentedSyntax: true,' + eol + 
+          '  sourceMap: true' + eol + 
+          '}));'
         break;
     }
 
@@ -339,7 +345,7 @@ function createApplication(app_name, path) {
     pkg.dependencies = sortedObject(pkg.dependencies);
 
     // write files
-    write(path + '/package.json', JSON.stringify(pkg, null, 2) + '\n');
+    write(path + '/package.json', JSON.stringify(pkg, null, 2) + eol);
     write(path + '/app.js', app.render())
     mkdir(path + '/bin', function(){
       write(path + '/bin/www', www.render(), 0755)
@@ -472,7 +478,7 @@ function main() {
   
   // Default view engine (a value of true here indicates the view engine has not been otherwise specified)
   if (program.view === true) {
-    warning("the default view engine will not be jade in future releases\nuse `--view=jade' or `--help' for additional options")
+    warning("the default view engine will not be jade in future releases" + eol + "use `--view=jade' or `--help' for additional options")
     program.view = 'jade'
   }
 
@@ -516,7 +522,7 @@ function renamedOption(originalName, newName) {
 
 function warning(message) {
   console.error()
-  message.split('\n').forEach(function (line) {
+  message.split(eol).forEach(function (line) {
     console.error('  warning: %s', line)
   })
   console.error()

--- a/bin/express
+++ b/bin/express
@@ -50,6 +50,7 @@ program
   .option('    --hbs', 'add handlebars engine support', renamedOption('--hbs', '--view=hbs'))
   .option('-H, --hogan', 'add hogan.js engine support', renamedOption('--hogan', '--view=hogan'))
   .option('-v, --view <engine>', 'add view <engine> support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)')
+  .option('    --no-view', 'use HTML directly instead of a view engine')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')
@@ -57,6 +58,39 @@ program
 
 if (!exit.exited) {
   main();
+}
+
+/**
+ * Replace placeholders for serving index page
+ */
+
+function addIndexServing(app, viewEngine) {
+  if (program.view == 'none') {
+    app.locals.requireIndexRoute = '';
+    app.locals.indexRoute = '';
+  } else {
+    app.locals.requireIndexRoute = eol + "var index = require('./routes/index');";
+    app.locals.indexRoute = eol + "app.use('/', index);";
+  }
+}
+
+/**
+ * Replace the template placeholders according to the configured view engine
+ */
+
+function addViewEngine(app, viewEngine) {
+  if (program.view == 'none') {
+    app.locals.viewEngineSetUp = '';
+    app.locals.renderError = "res.sendFile('error.html', {\n" +
+      "    root: __dirname + '/public/'\n" +
+      "  });";
+  } else {
+    app.locals.viewEngineSetUp = "\n" +
+      "// view engine setup\n" +
+      "app.set('views', path.join(__dirname, 'views'));\n" +
+      "app.set('view engine', '" + viewEngine + "');\n";
+    app.locals.renderError = "res.render('error');";
+  }
 }
 
 /**
@@ -134,6 +168,8 @@ function createApplication(app_name, path) {
   // JavaScript
   var app = loadTemplate('js/app.js');
   var www = loadTemplate('js/www');
+  var index = program.view == 'none' ? null : loadTemplate('js/routes/index.js');
+  var users = loadTemplate('js/routes/users.js');
 
   // App name
   www.locals.name = app_name
@@ -165,8 +201,11 @@ function createApplication(app_name, path) {
     });
 
     mkdir(path + '/routes', function(){
-      copy_template('js/routes/index.js', path + '/routes/index.js')
-      copy_template('js/routes/users.js', path + '/routes/users.js')
+      if (program.view != 'none') {
+        copy_template('js/routes/index.js', path + '/routes/index.js') 
+      }
+
+      copy_template('js/routes/users.js', path + '/routes/users.js') 
       complete();
     });
 
@@ -205,6 +244,10 @@ function createApplication(app_name, path) {
           copy_template('vash/layout.vash', path + '/views/layout.vash');
           copy_template('vash/error.vash', path + '/views/error.vash');
           break;
+        case 'none':
+          copy_template('none/index.html', path + '/public/index.html');
+          copy_template('none/error.html', path + '/public/error.html');
+          break;
       }
       complete();
     });
@@ -226,7 +269,10 @@ function createApplication(app_name, path) {
     }
 
     // Template support
-    app.locals.view = program.view
+    addViewEngine(app, program.view);
+
+    // Index route
+    addIndexServing(app, program.view);
 
     // package.json
     var pkg = {
@@ -265,6 +311,9 @@ function createApplication(app_name, path) {
         break;
       case 'vash':
         pkg.dependencies['vash'] = '~0.12.2';
+        break;
+      case 'none':
+        // No additional dependencies needed
         break;
       default:
     }
@@ -309,6 +358,7 @@ function copy_template(from, to) {
   from = path.join(__dirname, '..', 'templates', from);
   write(to, fs.readFileSync(from, 'utf-8'));
 }
+
 /**
  * Create an app name from a directory path, fitting npm naming requirements.
  *
@@ -372,6 +422,14 @@ function launchedFromCmd() {
 }
 
 /**
+ * Determine whether legacy view syntax (e.g. '--ejs') was used to specify view
+ */
+
+function legacyViewSpecified() {
+  return program.ejs || program.hbs || program.hogan || program.pug;
+}
+
+/**
  * Load template file.
  */
 
@@ -403,15 +461,17 @@ function main() {
   var appName = createAppName(path.resolve(destinationPath)) || 'hello-world'
 
   // View engine
-  if (program.view === undefined) {
+  if (!program.view) {
+    program.view = 'none'
+  } else if (legacyViewSpecified() && program.view === true) {
     if (program.ejs) program.view = 'ejs'
     if (program.hbs) program.view = 'hbs'
     if (program.hogan) program.view = 'hjs'
     if (program.pug) program.view = 'pug'
   }
-
-  // Default view engine
-  if (program.view === undefined) {
+  
+  // Default view engine (a value of true here indicates the view engine has not been otherwise specified)
+  if (program.view === true) {
     warning("the default view engine will not be jade in future releases\nuse `--view=jade' or `--help' for additional options")
     program.view = 'jade'
   }

--- a/templates/js/app.js
+++ b/templates/js/app.js
@@ -4,16 +4,11 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
-
-var index = require('./routes/index');
+{requireIndexRoute}
 var users = require('./routes/users');
 
 var app = express();
-
-// view engine setup
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', '{view}');
-
+{viewEngineSetUp}
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
@@ -21,8 +16,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());{css}
 app.use(express.static(path.join(__dirname, 'public')));
-
-app.use('/', index);
+{indexRoute}
 app.use('/users', users);
 
 // catch 404 and forward to error handler
@@ -40,7 +34,7 @@ app.use(function(err, req, res, next) {
 
   // render the error page
   res.status(err.status || 500);
-  res.render('error');
+  {renderError}
 });
 
 module.exports = app;

--- a/templates/none/error.html
+++ b/templates/none/error.html
@@ -1,0 +1,13 @@
+<html>
+
+<head>
+  <title>Express</title>
+  <link rel="stylesheet" href="/stylesheets/style.css">
+</head>
+
+<body>
+  <h1>Express</h1>
+  <p>An error has occurred</p>
+</body>
+
+</html>

--- a/templates/none/index.html
+++ b/templates/none/index.html
@@ -1,0 +1,13 @@
+<html>
+
+<head>
+  <title>Express</title>
+  <link rel="stylesheet" href="/stylesheets/style.css">
+</head>
+
+<body>
+  <h1>Express</h1>
+  <p>Welcome to Express</p>
+</body>
+
+</html>

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -343,6 +343,45 @@ describe('express(1)', function () {
     });
   });
 
+  describe('--ejs --view=pug', function () {
+    var ctx = setupTestEnvironment(this.fullTitle())
+
+    it('should create basic app with pug templates', function (done) {
+      run(ctx.dir, ['--ejs', '--view', 'pug'], function (err, stdout) {
+        if (err) return done(err)
+        ctx.files = parseCreatedFiles(stdout, ctx.dir)
+        assert.equal(ctx.files.length, 17)
+        done()
+      })
+    })
+
+    it('should have pug in package dependencies', function () {
+      var file = path.resolve(ctx.dir, 'package.json')
+      var contents = fs.readFileSync(file, 'utf8')
+      var dependencies = JSON.parse(contents).dependencies
+      assert.ok(typeof dependencies.pug === 'string')
+    })
+
+    it('should not have ejs in package dependencies', function () {
+      var file = path.resolve(ctx.dir, 'package.json')
+      var contents = fs.readFileSync(file, 'utf8')
+      var dependencies = JSON.parse(contents).dependencies
+      assert.ok(typeof dependencies.ejs === 'undefined')
+    })
+
+    it('should have pug templates', function () {
+      assert.notEqual(ctx.files.indexOf('views/error.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/index.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/layout.pug'), -1)
+    })
+
+    it('should not have ejs templates', function () {
+      assert.equal(ctx.files.indexOf('views/error.ejs'), -1)
+      assert.equal(ctx.files.indexOf('views/index.ejs'), -1)
+      assert.equal(ctx.files.indexOf('views/layout.ejs'), -1)
+    })
+  });
+
   describe('--git', function () {
     var ctx = setupTestEnvironment(this.fullTitle())
 
@@ -464,6 +503,60 @@ describe('express(1)', function () {
     it('should have hjs templates', function () {
       assert.notEqual(ctx.files.indexOf('views/error.hjs'), -1)
       assert.notEqual(ctx.files.indexOf('views/index.hjs'), -1)
+    })
+  })
+
+  describe('--no-view', function () {
+    var ctx = setupTestEnvironment(this.fullTitle())
+
+    it('should create basic app with no view engine', function (done) {
+      run(ctx.dir, ['--no-view'], function (err, stdout) {
+        if (err) return done(err)
+        ctx.files = parseCreatedFiles(stdout, ctx.dir)
+        assert.equal(ctx.files.length, 15)
+        done()
+      })
+    })
+
+    it('should have basic files', function () {
+      assert.notEqual(ctx.files.indexOf('bin/www'), -1)
+      assert.notEqual(ctx.files.indexOf('app.js'), -1)
+      assert.notEqual(ctx.files.indexOf('package.json'), -1)
+    })
+
+    it('should have HTML files to serve', function () {
+      assert.notEqual(ctx.files.indexOf('public/index.html'), -1)
+      assert.notEqual(ctx.files.indexOf('public/error.html'), -1)
+    })
+
+    it('should have installable dependencies', function (done) {
+      this.timeout(30000)
+      npmInstall(ctx.dir, done)
+    })
+
+    it('should export an express app from app.js', function () {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+      assert.equal(typeof app, 'function')
+      assert.equal(typeof app.handle, 'function')
+    })
+
+    it('should respond to HTTP request', function (done) {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+
+      request(app)
+      .get('/')
+      .expect(200, /<title>Express<\/title>/, done)
+    })
+
+    it('should generate a 404', function (done) {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+
+      request(app)
+      .get('/does_not_exist')
+      .expect(404, /<p>An error has occurred<\/p>/, done)
     })
   })
 

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -3,6 +3,7 @@ var assert = require('assert');
 var exec = require('child_process').exec;
 var fs = require('fs');
 var mkdirp = require('mkdirp');
+var os = require('os');
 var path = require('path');
 var request = require('supertest');
 var rimraf = require('rimraf');
@@ -10,6 +11,7 @@ var spawn = require('child_process').spawn;
 var validateNpmName = require('validate-npm-package-name')
 
 var binPath = path.resolve(__dirname, '../bin/express');
+var eol = os.EOL;
 var TEMP_DIR = path.resolve(__dirname, '..', 'temp', String(process.pid + Math.random()))
 
 describe('express(1)', function () {
@@ -38,7 +40,7 @@ describe('express(1)', function () {
     });
 
     it('should print jade view warning', function () {
-      assert.equal(ctx.stderr, "\n  warning: the default view engine will not be jade in future releases\n  warning: use `--view=jade' or `--help' for additional options\n\n")
+      assert.equal(ctx.stderr, eol + "  warning: the default view engine will not be jade in future releases" + eol + "  warning: use `--view=jade' or `--help' for additional options" + eol + eol)
     })
 
     it('should provide debug instructions', function () {
@@ -60,23 +62,23 @@ describe('express(1)', function () {
     it('should have a package.json file', function () {
       var file = path.resolve(ctx.dir, 'package.json');
       var contents = fs.readFileSync(file, 'utf8');
-      assert.equal(contents, '{\n'
-        + '  "name": "express(1)-(no-args)",\n'
-        + '  "version": "0.0.0",\n'
-        + '  "private": true,\n'
-        + '  "scripts": {\n'
-        + '    "start": "node ./bin/www"\n'
-        + '  },\n'
-        + '  "dependencies": {\n'
-        + '    "body-parser": "~1.16.0",\n'
-        + '    "cookie-parser": "~1.4.3",\n'
-        + '    "debug": "~2.6.0",\n'
-        + '    "express": "~4.14.1",\n'
-        + '    "jade": "~1.11.0",\n'
-        + '    "morgan": "~1.8.0",\n'
-        + '    "serve-favicon": "~2.3.2"\n'
-        + '  }\n'
-        + '}\n');
+      assert.equal(contents, '{' + eol
+        + '  "name": "express(1)-(no-args)",' + eol  
+        + '  "version": "0.0.0",' + eol  
+        + '  "private": true,' + eol  
+        + '  "scripts": {' + eol  
+        + '    "start": "node ./bin/www"' + eol  
+        + '  },' + eol  
+        + '  "dependencies": {' + eol  
+        + '    "body-parser": "~1.16.0",' + eol  
+        + '    "cookie-parser": "~1.4.3",' + eol  
+        + '    "debug": "~2.6.0",' + eol  
+        + '    "express": "~4.14.1",' + eol  
+        + '    "jade": "~1.11.0",' + eol  
+        + '    "morgan": "~1.8.0",' + eol  
+        + '    "serve-favicon": "~2.3.2"' + eol  
+        + '  }' + eol  
+        + '}' + eol); 
     });
 
     it('should have installable dependencies', function (done) {
@@ -1112,5 +1114,6 @@ function stripColors (str) {
 }
 
 function stripWarnings (str) {
-  return str.replace(/\n(?:  warning: [^\n]+\n)+\n/g, '')
+  var warningRegex = new RegExp(eol + "(?:  warning: [^" + eol + "]+" + eol + ")+" + eol, "g")
+  return str.replace(warningRegex, '')
 }

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -12,6 +12,8 @@ var validateNpmName = require('validate-npm-package-name')
 
 var binPath = path.resolve(__dirname, '../bin/express');
 var eol = os.EOL;
+// Newlines end up mixed between platforms, so need to match either
+var eolPattern = "(?:\\r\\n?|\\n)";
 var TEMP_DIR = path.resolve(__dirname, '..', 'temp', String(process.pid + Math.random()))
 
 describe('express(1)', function () {
@@ -40,7 +42,9 @@ describe('express(1)', function () {
     });
 
     it('should print jade view warning', function () {
-      assert.equal(ctx.stderr, eol + "  warning: the default view engine will not be jade in future releases" + eol + "  warning: use `--view=jade' or `--help' for additional options" + eol + eol)
+      var warningRegex = new RegExp(eolPattern + "  warning: the default view engine will not be jade in future releases" 
+        + eolPattern + "  warning: use `--view=jade' or `--help' for additional options" + eolPattern + eolPattern, "g")
+      assert.ok(warningRegex.test(ctx.stderr));
     })
 
     it('should provide debug instructions', function () {
@@ -62,23 +66,24 @@ describe('express(1)', function () {
     it('should have a package.json file', function () {
       var file = path.resolve(ctx.dir, 'package.json');
       var contents = fs.readFileSync(file, 'utf8');
-      assert.equal(contents, '{' + eol
-        + '  "name": "express(1)-(no-args)",' + eol  
-        + '  "version": "0.0.0",' + eol  
-        + '  "private": true,' + eol  
-        + '  "scripts": {' + eol  
-        + '    "start": "node ./bin/www"' + eol  
-        + '  },' + eol  
-        + '  "dependencies": {' + eol  
-        + '    "body-parser": "~1.16.0",' + eol  
-        + '    "cookie-parser": "~1.4.3",' + eol  
-        + '    "debug": "~2.6.0",' + eol  
-        + '    "express": "~4.14.1",' + eol  
-        + '    "jade": "~1.11.0",' + eol  
-        + '    "morgan": "~1.8.0",' + eol  
-        + '    "serve-favicon": "~2.3.2"' + eol  
-        + '  }' + eol  
-        + '}' + eol); 
+      var packageRegex = new RegExp('{' + eolPattern
+        + '  "name": "express\\(1\\)-\\(no-args\\)",' + eolPattern  
+        + '  "version": "0.0.0",' + eolPattern  
+        + '  "private": true,' + eolPattern  
+        + '  "scripts": {' + eolPattern  
+        + '    "start": "node ./bin/www"' + eolPattern  
+        + '  },' + eolPattern  
+        + '  "dependencies": {' + eolPattern  
+        + '    "body-parser": "~1.16.0",' + eolPattern  
+        + '    "cookie-parser": "~1.4.3",' + eolPattern  
+        + '    "debug": "~2.6.0",' + eolPattern  
+        + '    "express": "~4.14.1",' + eolPattern  
+        + '    "jade": "~1.11.0",' + eolPattern  
+        + '    "morgan": "~1.8.0",' + eolPattern  
+        + '    "serve-favicon": "~2.3.2"' + eolPattern  
+        + '  }' + eolPattern  
+        + '}' + eolPattern, "g");
+      assert.ok(packageRegex.test(contents));
     });
 
     it('should have installable dependencies', function (done) {
@@ -1114,6 +1119,6 @@ function stripColors (str) {
 }
 
 function stripWarnings (str) {
-  var warningRegex = new RegExp(eol + "(?:  warning: [^" + eol + "]+" + eol + ")+" + eol, "g")
+  var warningRegex = new RegExp(eolPattern + "(?:  warning: [^\\r\\n]+" + eolPattern + ")+" + eolPattern, "g")
   return str.replace(warningRegex, '')
 }


### PR DESCRIPTION
Add '--none' flag to avoid installing any view engine. Serve static HTML files in place of the index and error views.