### PR TITLE
#152: Add option for no view engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This generator can also be further configured with the following command line fl
         --hbs            add handlebars engine support
     -H, --hogan          add hogan.js engine support
     -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
+        --no-view       use HTML directly instead of a view engine
     -c, --css <engine>   add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git            add .gitignore
     -f, --force          force on non-empty directory

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -55,6 +55,7 @@ program
   .option('    --hbs', 'add handlebars engine support', renamedOption('--hbs', '--view=hbs'))
   .option('-H, --hogan', 'add hogan.js engine support', renamedOption('--hogan', '--view=hogan'))
   .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)')
+  .option('    --no-view', 'use HTML directly instead of a view engine')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')
@@ -178,35 +179,44 @@ function createApplication (name, dir) {
 
   // copy route templates
   mkdir(dir, 'routes')
-  copyTemplateMulti('js/routes', dir + '/routes', '*.js')
+  if (program.view == null) {
+    // Serve the index route statically, so only copy users route
+    copyTemplateMulti('js/routes', dir + '/routes', 'users.js')
+  } else {
+    copyTemplateMulti('js/routes', dir + '/routes', '*.js')
+  }
 
-  // copy view templates
-  mkdir(dir, 'views')
-  switch (program.view) {
-    case 'dust':
-      copyTemplateMulti('views', dir + '/views', '*.dust')
-      break
-    case 'ejs':
-      copyTemplateMulti('views', dir + '/views', '*.ejs')
-      break
-    case 'jade':
-      copyTemplateMulti('views', dir + '/views', '*.jade')
-      break
-    case 'hjs':
-      copyTemplateMulti('views', dir + '/views', '*.hjs')
-      break
-    case 'hbs':
-      copyTemplateMulti('views', dir + '/views', '*.hbs')
-      break
-    case 'pug':
-      copyTemplateMulti('views', dir + '/views', '*.pug')
-      break
-    case 'twig':
-      copyTemplateMulti('views', dir + '/views', '*.twig')
-      break
-    case 'vash':
-      copyTemplateMulti('views', dir + '/views', '*.vash')
-      break
+  if (program.view == null) {
+    copyTemplateMulti('views', dir + '/public', '*.html')
+  } else {
+    // copy view templates
+    mkdir(dir, 'views')
+    switch (program.view) {
+      case 'dust':
+        copyTemplateMulti('views', dir + '/views', '*.dust')
+        break
+      case 'ejs':
+        copyTemplateMulti('views', dir + '/views', '*.ejs')
+        break
+      case 'jade':
+        copyTemplateMulti('views', dir + '/views', '*.jade')
+        break
+      case 'hjs':
+        copyTemplateMulti('views', dir + '/views', '*.hjs')
+        break
+      case 'hbs':
+        copyTemplateMulti('views', dir + '/views', '*.hbs')
+        break
+      case 'pug':
+        copyTemplateMulti('views', dir + '/views', '*.pug')
+        break
+      case 'twig':
+        copyTemplateMulti('views', dir + '/views', '*.twig')
+        break
+      case 'vash':
+        copyTemplateMulti('views', dir + '/views', '*.vash')
+        break
+    }
   }
 
   // CSS Engine support
@@ -404,6 +414,14 @@ function launchedFromCmd () {
 }
 
 /**
+ * Determine whether legacy view syntax (e.g. '--ejs') was used to specify view
+ */
+
+function legacyViewSpecified () {
+  return program.ejs || program.hbs || program.hogan || program.pug
+}
+
+/**
  * Load template file.
  */
 
@@ -433,7 +451,9 @@ function main () {
   var appName = createAppName(path.resolve(destinationPath)) || 'hello-world'
 
   // View engine
-  if (program.view === undefined) {
+  if (program.view === false) {
+    program.view = null
+  } else if (legacyViewSpecified()) {
     if (program.ejs) program.view = 'ejs'
     if (program.hbs) program.view = 'hbs'
     if (program.hogan) program.view = 'hjs'
@@ -441,7 +461,7 @@ function main () {
   }
 
   // Default view engine
-  if (program.view === undefined) {
+  if (program.view === true) {
     warning('the default view engine will not be jade in future releases\n' +
       "use `--view=jade' or `--help' for additional options")
     program.view = 'jade'

--- a/templates/js/app.js.ejs
+++ b/templates/js/app.js.ejs
@@ -7,11 +7,14 @@ var cookieParser = require('cookie-parser');
 var <%- variable %> = require('<%- modules[variable] %>');
 <% }); -%>
 
+<% if (view.engine) { -%>
 var index = require('./routes/index');
+<% } -%>
 var users = require('./routes/users');
 
 var app = express();
 
+<% if (view.engine) { -%>
 // view engine setup
 <% if (view.render) { -%>
 app.engine('<%- view.engine %>', <%- view.render %>);
@@ -19,6 +22,7 @@ app.engine('<%- view.engine %>', <%- view.render %>);
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', '<%- view.engine %>');
 
+<% } -%>
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
@@ -30,7 +34,9 @@ app.use(<%- use %>);
 <% }); -%>
 app.use(express.static(path.join(__dirname, 'public')));
 
+<% if (view.engine) { -%>
 app.use('/', index);
+<% } -%>
 app.use('/users', users);
 
 // catch 404 and forward to error handler
@@ -48,7 +54,13 @@ app.use(function(err, req, res, next) {
 
   // render the error page
   res.status(err.status || 500);
+<% if (view.engine) { -%>
   res.render('error');
+<% } else { -%>
+  res.sendFile('error.html', {
+    root: __dirname + '/public/'
+  });
+<% } -%>
 });
 
 module.exports = app;

--- a/templates/views/error.html
+++ b/templates/views/error.html
@@ -1,0 +1,13 @@
+<html>
+
+<head>
+  <title>Express</title>
+  <link rel="stylesheet" href="/stylesheets/style.css">
+</head>
+
+<body>
+  <h1>Express</h1>
+  <p>An error has occurred</p>
+</body>
+
+</html>

--- a/templates/views/index.html
+++ b/templates/views/index.html
@@ -1,0 +1,13 @@
+<html>
+
+<head>
+  <title>Express</title>
+  <link rel="stylesheet" href="/stylesheets/style.css">
+</head>
+
+<body>
+  <h1>Express</h1>
+  <p>Welcome to Express</p>
+</body>
+
+</html>

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -521,6 +521,60 @@ describe('express(1)', function () {
     })
   })
 
+  describe('--no-view', function () {
+    var ctx = setupTestEnvironment(this.fullTitle())
+
+    it('should create basic app with no view engine', function (done) {
+      run(ctx.dir, ['--no-view'], function (err, stdout) {
+        if (err) return done(err)
+        ctx.files = utils.parseCreatedFiles(stdout, ctx.dir)
+        assert.equal(ctx.files.length, 13)
+        done()
+      })
+    })
+
+    it('should have basic files', function () {
+      assert.notEqual(ctx.files.indexOf('bin/www'), -1)
+      assert.notEqual(ctx.files.indexOf('app.js'), -1)
+      assert.notEqual(ctx.files.indexOf('package.json'), -1)
+    })
+
+    it('should have HTML files to serve', function () {
+      assert.notEqual(ctx.files.indexOf('public/index.html'), -1)
+      assert.notEqual(ctx.files.indexOf('public/error.html'), -1)
+    })
+
+    it('should have installable dependencies', function (done) {
+      this.timeout(30000)
+      npmInstall(ctx.dir, done)
+    })
+
+    it('should export an express app from app.js', function () {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+      assert.equal(typeof app, 'function')
+      assert.equal(typeof app.handle, 'function')
+    })
+
+    it('should respond to HTTP request', function (done) {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+
+      request(app)
+      .get('/')
+      .expect(200, /<title>Express<\/title>/, done)
+    })
+
+    it('should generate a 404', function (done) {
+      var file = path.resolve(ctx.dir, 'app.js')
+      var app = require(file)
+
+      request(app)
+      .get('/does_not_exist')
+      .expect(404, /<p>An error has occurred<\/p>/, done)
+    })
+  })
+
   describe('--pug', function () {
     var ctx = setupTestEnvironment(this.fullTitle())
 


### PR DESCRIPTION
A rework of [this declined PR](https://github.com/expressjs/generator/pull/153).

Summary:
- Passing the `--no-view` option excludes the view engine set up and corresponding render calls, instead statically serving HTML
- I made an effort to avoid the pitfalls of the previous attempt by using `null` instead of `'none'`. This should remove the concerns around the previously erroneous `view=none` behavior, now treating that the same as `view=foo`.

With the recent addition of the lint configuration, hopefully there'll be less opportunity for stylistic errors...