### PR TITLE
Printing the port without running debug mode

### DIFF
--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -93,4 +93,4 @@ function onListening() {
  * Print the port used from the server
  */
  
-console.log("Running on http://localhost:" + port);
+console.log("Running on http://localhost:" + app.get('port'));

--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -88,3 +88,6 @@ function onListening() {
     : 'port ' + addr.port;
   debug('Listening on ' + bind);
 }
+// Print the port used from the server
+
+console.log("Running on http://localhost:"+ port);

--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -93,4 +93,4 @@ function onListening() {
  * Print the port used from the server
  */
  
-console.log("Running on http://localhost:"+ port);
+console.log("Running on http://localhost:" + port);

--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -88,6 +88,9 @@ function onListening() {
     : 'port ' + addr.port;
   debug('Listening on ' + bind);
 }
-// Print the port used from the server
 
+/**
+ * Print the port used from the server
+ */
+ 
 console.log("Running on http://localhost:"+ port);


### PR DESCRIPTION
When using the generator I always end up printing the port on the terminal to have an easy way to quickly jump to the browser and the app. Its more for convenience as I don't always want to run from the debug mode. Plus I also usually change the port with an env file so its not always 3000. If there is a reason why this should not be done feel free to ignore this and please tell me why what am I doing is not correct. I though it might be a convenient addition tho. 