### PR TITLE
changed handlebars package

### DIFF
--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -257,6 +257,18 @@ function createApplication (name, path) {
           render: 'adaro.dust()'
         }
         break
+      case 'hbs':
+        app.locals.modules.handlebars = 'express-handlebars'
+        app.locals.view = {
+          engine: program.view,
+          render: 'handlebars.create({\n'
+            + '  extname:       \'hbs\',\n'
+            + '  layoutsDir:    path.join(__dirname, \'views\'),\n'
+            + '  partialsDir:   path.join(__dirname, \'views\', \'partials\'),\n'
+            + '  defaultLayout: \'layout\'\n'
+            + '}).engine'
+        }
+        break
       default:
         app.locals.view = {
           engine: program.view
@@ -296,7 +308,7 @@ function createApplication (name, path) {
         pkg.dependencies['hjs'] = '~0.0.6'
         break
       case 'hbs':
-        pkg.dependencies['hbs'] = '~4.0.1'
+        pkg.dependencies['express-handlebars'] = '^3.0.0'
         break
       case 'pug':
         pkg.dependencies['pug'] = '~2.0.0-beta11'

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -308,7 +308,7 @@ function createApplication (name, path) {
         pkg.dependencies['hjs'] = '~0.0.6'
         break
       case 'hbs':
-        pkg.dependencies['express-handlebars'] = '^3.0.0'
+        pkg.dependencies['express-handlebars'] = '~3.0.0'
         break
       case 'pug':
         pkg.dependencies['pug'] = '~2.0.0-beta11'

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -261,12 +261,12 @@ function createApplication (name, path) {
         app.locals.modules.handlebars = 'express-handlebars'
         app.locals.view = {
           engine: program.view,
-          render: 'handlebars.create({\n'
-            + '  extname:       \'hbs\',\n'
-            + '  layoutsDir:    path.join(__dirname, \'views\'),\n'
-            + '  partialsDir:   path.join(__dirname, \'views\', \'partials\'),\n'
-            + '  defaultLayout: \'layout\'\n'
-            + '}).engine'
+          render: 'handlebars.create({\n' +
+            '  extname:       \'hbs\',\n' +
+            '  layoutsDir:    path.join(__dirname, \'views\'),\n' +
+            '  partialsDir:   path.join(__dirname, \'views\', \'partials\'),\n' +
+            '  defaultLayout: \'layout\'\n' +
+            '}).engine'
         }
         break
       default:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-generator",
   "description": "Express' application generator",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Aaron Heckmann <aaron.heckmann+github@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-generator",
   "description": "Express' application generator",
-  "version": "4.16.0",
+  "version": "4.15.0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Aaron Heckmann <aaron.heckmann+github@gmail.com>",

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -411,7 +411,7 @@ describe('express(1)', function () {
       var file = path.resolve(ctx.dir, 'package.json')
       var contents = fs.readFileSync(file, 'utf8')
       var dependencies = JSON.parse(contents).dependencies
-      assert.ok(typeof dependencies.hbs === 'string')
+      assert.ok(typeof dependencies.['express-handlebars'] === 'string')
     })
 
     it('should have hbs templates', function () {

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -661,7 +661,7 @@ describe('express(1)', function () {
         var file = path.resolve(ctx.dir, 'package.json')
         var contents = fs.readFileSync(file, 'utf8')
         var dependencies = JSON.parse(contents).dependencies
-        assert.ok(typeof dependencies.hbs === 'string')
+        assert.ok(typeof dependencies['express-handlebars'] === 'string')
       })
 
       it('should have hbs templates', function () {

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -411,7 +411,7 @@ describe('express(1)', function () {
       var file = path.resolve(ctx.dir, 'package.json')
       var contents = fs.readFileSync(file, 'utf8')
       var dependencies = JSON.parse(contents).dependencies
-      assert.ok(typeof dependencies.['express-handlebars'] === 'string')
+      assert.ok(typeof dependencies['express-handlebars'] === 'string')
     })
 
     it('should have hbs templates', function () {


### PR DESCRIPTION
[This other package](https://www.npmjs.com/package/express-handlebars) is, for one:

> A Handlebars view engine for Express which doesn't suck.

and also, one which [allows for partials](https://github.com/ericf/express-handlebars) (search for partialsdir on page) which is super useful for me. I'm happy to work with you guys to figure out how to get this integrated into this package, cause theres a handful of live sites/private apis that i made from this tool and its super useful for me, and now that I'm getting into web development more commercially, i found myself editing this bit in and figured its time to give back.