### PR TITLE
Add `.DS_Store` to gitignore

### DIFF
--- a/templates/js/gitignore
+++ b/templates/js/gitignore
@@ -28,3 +28,7 @@ node_modules
 
 # Debug log from npm
 npm-debug.log
+
+# File system
+.DS_Store
+


### PR DESCRIPTION
Thought I would start a discussion around this.  I don't have a strong opinion either way, but I'm always manually adding this to `.gitignore` since most projects I work on have at least one developer on a Mac.