### PR TITLE
Make pug the default template engine instead of jade

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This generator can also be further configured with the following command line fl
         --pug            add pug engine support
         --hbs            add handlebars engine support
     -H, --hogan          add hogan.js engine support
-    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
+    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to pug)
     -c, --css <engine>   add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git            add .gitignore
     -f, --force          force on non-empty directory

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -52,7 +52,7 @@ program
   .option('    --pug', 'add pug engine support', renamedOption('--pug', '--view=pug'))
   .option('    --hbs', 'add handlebars engine support', renamedOption('--hbs', '--view=hbs'))
   .option('-H, --hogan', 'add hogan.js engine support', renamedOption('--hogan', '--view=hogan'))
-  .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)')
+  .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to pug)')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
   .option('-f, --force', 'force on non-empty directory')
@@ -300,7 +300,7 @@ function createApplication (name, path) {
         pkg.dependencies['hbs'] = '~4.0.1'
         break
       case 'pug':
-        pkg.dependencies['pug'] = '2.0.0-beta11'
+        pkg.dependencies['pug'] = '~2.0.0-rc.4'
         break
       case 'twig':
         pkg.dependencies['twig'] = '~0.10.3'
@@ -446,9 +446,9 @@ function main () {
 
   // Default view engine
   if (program.view === undefined) {
-    warning('the default view engine will not be jade in future releases\n' +
-      "use `--view=jade' or `--help' for additional options")
-    program.view = 'jade'
+    warning('the default view engine has changed from jade to pug\n' +
+      "use `--view=pug' or `--help' for additional options")
+    program.view = 'pug'
   }
 
   // Generate application

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -41,7 +41,7 @@ describe('express(1)', function () {
     })
 
     it('should print jade view warning', function () {
-      assert.equal(ctx.stderr, "\n  warning: the default view engine will not be jade in future releases\n  warning: use `--view=jade' or `--help' for additional options\n\n")
+      assert.equal(ctx.stderr, "\n  warning: the default view engine has changed from jade to pug\n  warning: use `--view=pug' or `--help' for additional options\n\n")
     })
 
     it('should provide debug instructions', function () {
@@ -54,10 +54,10 @@ describe('express(1)', function () {
       assert.notEqual(ctx.files.indexOf('package.json'), -1)
     })
 
-    it('should have jade templates', function () {
-      assert.notEqual(ctx.files.indexOf('views/error.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('views/index.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('views/layout.jade'), -1)
+    it('should have pug templates', function () {
+      assert.notEqual(ctx.files.indexOf('views/error.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/index.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/layout.pug'), -1)
     })
 
     it('should have a package.json file', function () {
@@ -75,8 +75,8 @@ describe('express(1)', function () {
         '    "cookie-parser": "~1.4.3",\n' +
         '    "debug": "~2.6.9",\n' +
         '    "express": "~4.15.5",\n' +
-        '    "jade": "~1.11.0",\n' +
         '    "morgan": "~1.9.0",\n' +
+        '    "pug": "~2.0.0-rc.4",\n' +
         '    "serve-favicon": "~2.4.5"\n' +
         '  }\n' +
         '}\n')
@@ -381,10 +381,10 @@ describe('express(1)', function () {
       assert.notEqual(ctx.files.indexOf('.gitignore'), -1, 'should have .gitignore file')
     })
 
-    it('should have jade templates', function () {
-      assert.notEqual(ctx.files.indexOf('views/error.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('views/index.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('views/layout.jade'), -1)
+    it('should have pug templates', function () {
+      assert.notEqual(ctx.files.indexOf('views/error.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/index.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/layout.pug'), -1)
     })
   })
 


### PR DESCRIPTION
Make pug the default template engine instead of jade.  Jade has been renamed to pug due to trademark issues.  The last version of jade has known vulnerabilities per https://snyk.io/test/npm/jade which results in express-generator projects by default have vulnerabilities in their dependencies out of the box.