### PR TITLE
Express 4.16.2 with built-in body parser

### DIFF
--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -274,10 +274,9 @@ function createApplication (name, path) {
         start: 'node ./bin/www'
       },
       dependencies: {
-        'body-parser': '~1.18.2',
         'cookie-parser': '~1.4.3',
         'debug': '~2.6.9',
-        'express': '~4.15.5',
+        'express': '~4.16.2',
         'morgan': '~1.9.0',
         'serve-favicon': '~2.4.5'
       }

--- a/templates/js/app.js.ejs
+++ b/templates/js/app.js.ejs
@@ -3,7 +3,6 @@ var path = require('path');
 var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
-var bodyParser = require('body-parser');
 <% Object.keys(modules).forEach(function (variable) { -%>
 var <%- variable %> = require('<%- modules[variable] %>');
 <% }); -%>
@@ -23,8 +22,8 @@ app.set('view engine', '<%- view.engine %>');
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 <% uses.forEach(function (use) { -%>
 app.use(<%- use %>);


### PR DESCRIPTION
Express 4.16.2 includes a security fix and body-parser built-in. No need to require it anymore.
Makes the code smaller and more simple.