### PR TITLE
Remove redundant code

### DIFF
--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -67,11 +67,9 @@ function onError(error) {
     case 'EACCES':
       console.error(bind + ' requires elevated privileges');
       process.exit(1);
-      break;
     case 'EADDRINUSE':
       console.error(bind + ' is already in use');
       process.exit(1);
-      break;
     default:
       throw error;
   }


### PR DESCRIPTION
Because `process.exit(1)` has exited the process, `break` is redundant.

If you use eslint, the error is as follows.

![image](https://user-images.githubusercontent.com/8413791/36057756-b876eef6-0e4d-11e8-8cb6-7fb3c8952066.png)
