### PR TITLE
When forced, check for existing package.json and clone it's dependencies

### DIFF
--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -144,7 +144,6 @@ function createApplication (name, dir, force) {
   if(force){
     existingPackage = require(path.join(dir, 'package.json'))
     existingDependencies = existingPackage.dependencies
-    existingDevdependencies = existingPackage.devDependencies
   }
 
   var pkg = {
@@ -157,8 +156,7 @@ function createApplication (name, dir, force) {
     dependencies: Object.assign({
       'debug': '~2.6.9',
       'express': '~4.16.0'
-    }, existingDependencies),
-    devDependencies = existingDevdependencies
+    }, existingDependencies)
   }
 
   // JavaScript

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -133,10 +133,20 @@ function copyTemplateMulti (fromDir, toDir, nameGlob) {
  * @param {string} dir
  */
 
-function createApplication (name, dir) {
+function createApplication (name, dir, force) {
   console.log()
 
   // Package
+  var existingPackage
+  var existingDependencies
+  var existingDevdependencies
+
+  if(force){
+    existingPackage = require(path.join(dir, 'package.json'))
+    existingDependencies = existingPackage.dependencies
+    existingDevdependencies = existingPackage.devDependencies
+  }
+
   var pkg = {
     name: name,
     version: '0.0.0',
@@ -144,10 +154,11 @@ function createApplication (name, dir) {
     scripts: {
       start: 'node ./bin/www'
     },
-    dependencies: {
+    dependencies: Object.assign({
       'debug': '~2.6.9',
       'express': '~4.16.0'
-    }
+    }, existingDependencies),
+    existingDevdependencies
   }
 
   // JavaScript
@@ -469,7 +480,7 @@ function main () {
   // Generate application
   emptyDirectory(destinationPath, function (empty) {
     if (empty || program.force) {
-      createApplication(appName, destinationPath)
+      createApplication(appName, destinationPath, program.force)
     } else {
       confirm('destination is not empty, continue? [y/N] ', function (ok) {
         if (ok) {

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -158,7 +158,7 @@ function createApplication (name, dir, force) {
       'debug': '~2.6.9',
       'express': '~4.16.0'
     }, existingDependencies),
-    existingDevdependencies
+    devDependencies = existingDevdependencies
   }
 
   // JavaScript


### PR DESCRIPTION
When generating an express app, if the dev decides to force on a directory that isn't empty, my commit will check if there's already a package.json in that directory and copy it's dependencies and devdependencies. it happens if and only if the force option is added.