### PR TITLE
When forced, check if there's an existing package.json and clone dependencies

### DIFF
--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -133,10 +133,20 @@ function copyTemplateMulti (fromDir, toDir, nameGlob) {
  * @param {string} dir
  */
 
-function createApplication (name, dir) {
+function createApplication (name, dir, force) {
   console.log()
 
   // Package
+  var existingPackage
+  var existingDependencies
+  var existingDevdependencies
+
+  if (force) {
+    existingPackage = require(path.join(dir, 'package.json'))
+    existingDependencies = existingPackage.dependencies
+    existingDevdependencies = existingDependencies
+  }
+
   var pkg = {
     name: name,
     version: '0.0.0',
@@ -148,6 +158,13 @@ function createApplication (name, dir) {
       'debug': '~2.6.9',
       'express': '~4.16.0'
     }
+  }
+
+  if (existingDependencies) {
+    for (var dependency in existingDependencies) {
+      pkg.dependencies[dependency] = existingDependencies[dependency]
+    }
+    pkg.devDependencies = existingDevdependencies
   }
 
   // JavaScript
@@ -469,7 +486,7 @@ function main () {
   // Generate application
   emptyDirectory(destinationPath, function (empty) {
     if (empty || program.force) {
-      createApplication(appName, destinationPath)
+      createApplication(appName, destinationPath, program.force)
     } else {
       confirm('destination is not empty, continue? [y/N] ', function (ok) {
         if (ok) {

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -144,7 +144,7 @@ function createApplication (name, dir, force) {
   if (force) {
     existingPackage = require(path.join(dir, 'package.json'))
     existingDependencies = existingPackage.dependencies
-    existingDevdependencies = existingDependencies
+    existingDevdependencies = existingPackage.devDependencies
   }
 
   var pkg = {

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -491,7 +491,7 @@ function main () {
       confirm('destination is not empty, continue? [y/N] ', function (ok) {
         if (ok) {
           process.stdin.destroy()
-          createApplication(appName, destinationPath)
+          createApplication(appName, destinationPath, force)
         } else {
           console.error('aborting')
           exit(1)


### PR DESCRIPTION
When the command is forced on a directory that isn't empty, my changes will check if the user has an existing package.json file and clone it's dependencies instead of overwriting it.