### PR TITLE
Add --es6 option to enable ES6 compliant syntax

### DIFF
--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -171,6 +171,20 @@ function createApplication (name, dir) {
   app.locals.es6 = program.es6
   app.locals.varconst = varconst
 
+  var genFunc = null
+
+  if (program.es6) {
+    genFunc = function (params) {
+      return '(' + params.join(', ') + ') =>'
+    }
+  } else {
+    genFunc = function (params) {
+      return 'function (' + params.join(', ') + ')'
+    }
+  }
+
+  app.locals.genFunc = genFunc
+
   // App modules
   app.locals.localModules = Object.create(null)
   app.locals.modules = Object.create(null)

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -74,7 +74,7 @@ if (!exit.exited) {
  * Install an around function; AOP.
  */
 
-function around(obj, method, fn) {
+function around (obj, method, fn) {
   var old = obj[method]
 
   obj[method] = function () {
@@ -88,7 +88,7 @@ function around(obj, method, fn) {
  * Install a before function; AOP.
  */
 
-function before(obj, method, fn) {
+function before (obj, method, fn) {
   var old = obj[method]
 
   obj[method] = function () {
@@ -101,7 +101,7 @@ function before(obj, method, fn) {
  * Prompt for confirmation on STDOUT/STDIN
  */
 
-function confirm(msg, callback) {
+function confirm (msg, callback) {
   var rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -117,7 +117,7 @@ function confirm(msg, callback) {
  * Copy file from template directory.
  */
 
-function copyTemplate(from, to) {
+function copyTemplate (from, to) {
   write(to, fs.readFileSync(path.join(TEMPLATE_DIR, from), 'utf-8'))
 }
 
@@ -125,7 +125,7 @@ function copyTemplate(from, to) {
  * Copy multiple files from template directory.
  */
 
-function copyTemplateMulti(fromDir, toDir, nameGlob) {
+function copyTemplateMulti (fromDir, toDir, nameGlob) {
   fs.readdirSync(path.join(TEMPLATE_DIR, fromDir))
     .filter(minimatch.filter(nameGlob, { matchBase: true }))
     .forEach(function (name) {
@@ -140,7 +140,7 @@ function copyTemplateMulti(fromDir, toDir, nameGlob) {
  * @param {string} dir
  */
 
-function createApplication(name, dir) {
+function createApplication (name, dir) {
   console.log()
 
   // Package
@@ -382,7 +382,7 @@ function createApplication(name, dir) {
  * @param {String} pathName
  */
 
-function createAppName(pathName) {
+function createAppName (pathName) {
   return path.basename(pathName)
     .replace(/[^A-Za-z0-9.-]+/g, '-')
     .replace(/^[-_.]+|-+$/g, '')
@@ -396,7 +396,7 @@ function createAppName(pathName) {
  * @param {Function} fn
  */
 
-function emptyDirectory(dir, fn) {
+function emptyDirectory (dir, fn) {
   fs.readdir(dir, function (err, files) {
     if (err && err.code !== 'ENOENT') throw err
     fn(!files || !files.length)
@@ -407,11 +407,11 @@ function emptyDirectory(dir, fn) {
  * Graceful exit for async STDIO
  */
 
-function exit(code) {
+function exit (code) {
   // flush output for Node.js Windows pipe bug
   // https://github.com/joyent/node/issues/6247 is just one bug example
   // https://github.com/visionmedia/mocha/issues/333 has a good discussion
-  function done() {
+  function done () {
     if (!(draining--)) _exit(code)
   }
 
@@ -433,7 +433,7 @@ function exit(code) {
  * Determine if launched from cmd.exe
  */
 
-function launchedFromCmd() {
+function launchedFromCmd () {
   return process.platform === 'win32' &&
     process.env._ === undefined
 }
@@ -442,11 +442,11 @@ function launchedFromCmd() {
  * Load template file.
  */
 
-function loadTemplate(name) {
+function loadTemplate (name) {
   var contents = fs.readFileSync(path.join(__dirname, '..', 'templates', (name + '.ejs')), 'utf-8')
   var locals = Object.create(null)
 
-  function render() {
+  function render () {
     return ejs.render(contents, locals, {
       escape: util.inspect
     })
@@ -462,7 +462,7 @@ function loadTemplate(name) {
  * Main program.
  */
 
-function main() {
+function main () {
   // Path
   var destinationPath = program.args.shift() || '.'
 
@@ -509,7 +509,7 @@ function main() {
  * @param {string} dir
  */
 
-function mkdir(base, dir) {
+function mkdir (base, dir) {
   var loc = path.join(base, dir)
 
   console.log('   \x1b[36mcreate\x1b[0m : ' + loc + path.sep)
@@ -523,7 +523,7 @@ function mkdir(base, dir) {
  * @param {String} newName
  */
 
-function renamedOption(originalName, newName) {
+function renamedOption (originalName, newName) {
   return function (val) {
     warning(util.format("option `%s' has been renamed to `%s'", originalName, newName))
     return val
@@ -536,7 +536,7 @@ function renamedOption(originalName, newName) {
  * @param {String} message
  */
 
-function warning(message) {
+function warning (message) {
   console.error()
   message.split('\n').forEach(function (line) {
     console.error('  warning: %s', line)
@@ -551,7 +551,7 @@ function warning(message) {
  * @param {String} str
  */
 
-function write(file, str, mode) {
+function write (file, str, mode) {
   fs.writeFileSync(file, str, { mode: mode || MODE_0666 })
   console.log('   \x1b[36mcreate\x1b[0m : ' + file)
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ejs": "2.5.7",
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",
+    "semver": "^5.5.0",
     "sorted-object": "2.0.1"
   },
   "main": "bin/express-cli.js",

--- a/templates/js/app.js.ejs
+++ b/templates/js/app.js.ejs
@@ -1,17 +1,17 @@
 <% if (view) { -%>
-var createError = require('http-errors');
+<%- varconst %> createError = require('http-errors');
 <% } -%>
-var express = require('express');
-var path = require('path');
+<%- varconst %> express = require('express');
+<%- varconst %> path = require('path');
 <% Object.keys(modules).sort().forEach(function (variable) { -%>
-var <%- variable %> = require('<%- modules[variable] %>');
+<%- varconst %> <%- variable %> = require('<%- modules[variable] %>');
 <% }); -%>
 
 <% Object.keys(localModules).sort().forEach(function (variable) { -%>
-var <%- variable %> = require('<%- localModules[variable] %>');
+<%- varconst %> <%- variable %> = require('<%- localModules[variable] %>');
 <% }); -%>
 
-var app = express();
+<%- varconst %> app = express();
 
 <% if (view) { -%>
 // view engine setup

--- a/templates/js/app.js.ejs
+++ b/templates/js/app.js.ejs
@@ -37,7 +37,7 @@ app.use(function(req, res, next) {
 });
 
 // error handler
-app.use(function(err, req, res, next) {
+app.use(function (err, req, res, next) {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};

--- a/templates/js/app.js.ejs
+++ b/templates/js/app.js.ejs
@@ -32,12 +32,12 @@ app.use(<%= mount.path %>, <%- mount.code %>);
 
 <% if (view) { -%>
 // catch 404 and forward to error handler
-app.use(function(req, res, next) {
+app.use(<%- genFunc(['req', 'res', 'next']) %> {
   next(createError(404));
 });
 
 // error handler
-app.use(function (err, req, res, next) {
+app.use(<%- genFunc(['err', 'req', 'res', 'next']) %> {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};

--- a/templates/js/routes/es6/index.js
+++ b/templates/js/routes/es6/index.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+/* GET home page. */
+router.get('/', function(req, res, next) {
+  res.render('index', { title: 'Express' });
+});
+
+module.exports = router;

--- a/templates/js/routes/es6/index.js
+++ b/templates/js/routes/es6/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 /* GET home page. */
-router.get('/', function(req, res, next) {
+router.get('/', (req, res, next) => {
   res.render('index', { title: 'Express' });
 });
 

--- a/templates/js/routes/es6/users.js
+++ b/templates/js/routes/es6/users.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+/* GET users listing. */
+router.get('/', function(req, res, next) {
+  res.send('respond with a resource');
+});
+
+module.exports = router;

--- a/templates/js/routes/es6/users.js
+++ b/templates/js/routes/es6/users.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 /* GET users listing. */
-router.get('/', function(req, res, next) {
+router.get('/', (req, res, next) => {
   res.send('respond with a resource');
 });
 

--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -59,8 +59,8 @@ function onError(error) {
   }
 
   <%- varconst %> bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port;
+    ? `Pipe ${port}`
+    : `Port ${port}`;
 
   // handle specific listen errors with friendly messages
   switch (error.code) {

--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -33,17 +33,17 @@ server.on('listening', onListening);
  * Normalize a port into a number, string, or false.
  */
 
-function normalizePort(val) {
-  <%- varconst %> port = parseInt(val, 10);
+function normalizePort (val) {
+  <%- varconst %> parsedPort = parseInt(val, 10);
 
-  if (isNaN(port)) {
+  if (isNaN(parsedPort)) {
     // named pipe
     return val;
   }
 
-  if (port >= 0) {
+  if (parsedPort >= 0) {
     // port number
-    return port;
+    return parsedPort;
   }
 
   return false;
@@ -53,14 +53,20 @@ function normalizePort(val) {
  * Event listener for HTTP server "error" event.
  */
 
-function onError(error) {
+function onError (error) {
   if (error.syscall !== 'listen') {
     throw error;
   }
 
+<% if (es6) { -%>
   <%- varconst %> bind = typeof port === 'string'
     ? `Pipe ${port}`
     : `Port ${port}`;
+<% } else { -%>
+  <%- varconst %> bind = typeof port === 'string'
+    ? 'Pipe ' + port
+    : 'Port ' + port;
+<% } -%>
 
   // handle specific listen errors with friendly messages
   switch (error.code) {
@@ -71,7 +77,6 @@ function onError(error) {
       console.error(bind + ' requires elevated privileges');
 <% } -%>
       process.exit(1);
-      break;
     case 'EADDRINUSE':
 <% if (es6) { -%>
       console.error(`${bind} is already in use`);
@@ -79,7 +84,6 @@ function onError(error) {
       console.error(bind + ' is already in use');
 <% } -%>
       process.exit(1);
-      break;
     default:
       throw error;
   }
@@ -89,14 +93,17 @@ function onError(error) {
  * Event listener for HTTP server "listening" event.
  */
 
-function onListening() {
+function onListening () {
   <%- varconst %> addr = server.address();
+<% if (es6) { -%>
+  <%- varconst %> bind = typeof addr === 'string'
+    ? `pipe ${addr}`
+    : `port ${addr.port}`;
+  debug(`Listening on ${bind}`);
+<% } else { -%>
   <%- varconst %> bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
-<% if (es6) { -%>
-  debug(`Listening on ${bind}`);
-<% } else { -%>
   debug('Listening on ' + bind);
 <% } -%>
 }

--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -4,22 +4,22 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('<%- name %>:server');
-var http = require('http');
+<%- varconst %> app = require('../app');
+<%- varconst %> debug = require('debug')('<%- name %>:server');
+<%- varconst %> http = require('http');
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+<%- varconst %> port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
 /**
  * Create HTTP server.
  */
 
-var server = http.createServer(app);
+<%- varconst %> server = http.createServer(app);
 
 /**
  * Listen on provided port, on all network interfaces.
@@ -34,7 +34,7 @@ server.on('listening', onListening);
  */
 
 function normalizePort(val) {
-  var port = parseInt(val, 10);
+  <%- varconst %> port = parseInt(val, 10);
 
   if (isNaN(port)) {
     // named pipe
@@ -58,18 +58,26 @@ function onError(error) {
     throw error;
   }
 
-  var bind = typeof port === 'string'
+  <%- varconst %> bind = typeof port === 'string'
     ? 'Pipe ' + port
     : 'Port ' + port;
 
   // handle specific listen errors with friendly messages
   switch (error.code) {
     case 'EACCES':
+<% if (es6) { -%>
+      console.error(`${bind} requires elevated privileges`);
+<% } else { -%>
       console.error(bind + ' requires elevated privileges');
+<% } -%>
       process.exit(1);
       break;
     case 'EADDRINUSE':
+<% if (es6) { -%>
+      console.error(`${bind} is already in use`);
+<% } else { -%>
       console.error(bind + ' is already in use');
+<% } -%>
       process.exit(1);
       break;
     default:
@@ -82,9 +90,13 @@ function onError(error) {
  */
 
 function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
+  <%- varconst %> addr = server.address();
+  <%- varconst %> bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
+<% if (es6) { -%>
+  debug(`Listening on ${bind}`);
+<% } else { -%>
   debug('Listening on ' + bind);
+<% } -%>
 }

--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -77,6 +77,7 @@ function onError (error) {
       console.error(bind + ' requires elevated privileges');
 <% } -%>
       process.exit(1);
+      break;
     case 'EADDRINUSE':
 <% if (es6) { -%>
       console.error(`${bind} is already in use`);
@@ -84,6 +85,7 @@ function onError (error) {
       console.error(bind + ' is already in use');
 <% } -%>
       process.exit(1);
+      break;
     default:
       throw error;
   }

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -1151,7 +1151,7 @@ describe('--es6', function () {
   }
 })
 
-function npmInstall(dir, callback) {
+function npmInstall (dir, callback) {
   var env = utils.childEnvironment()
 
   exec('npm install', { cwd: dir, env: env }, function (err, stderr) {
@@ -1165,7 +1165,7 @@ function npmInstall(dir, callback) {
   })
 }
 
-function run(dir, args, callback) {
+function run (dir, args, callback) {
   runRaw(dir, args, function (err, code, stdout, stderr) {
     if (err) {
       return callback(err)
@@ -1184,7 +1184,7 @@ function run(dir, args, callback) {
   })
 }
 
-function runRaw(dir, args, callback) {
+function runRaw (dir, args, callback) {
   var argv = [BIN_PATH].concat(args)
   var binp = process.argv[0]
   var stderr = ''
@@ -1195,23 +1195,23 @@ function runRaw(dir, args, callback) {
   })
 
   child.stdout.setEncoding('utf8')
-  child.stdout.on('data', function ondata(str) {
+  child.stdout.on('data', function ondata (str) {
     stdout += str
   })
   child.stderr.setEncoding('utf8')
-  child.stderr.on('data', function ondata(str) {
+  child.stderr.on('data', function ondata (str) {
     stderr += str
   })
 
   child.on('close', onclose)
   child.on('error', callback)
 
-  function onclose(code) {
+  function onclose (code) {
     callback(null, code, stdout, stderr)
   }
 }
 
-function setupTestEnvironment(name) {
+function setupTestEnvironment (name) {
   var ctx = {}
 
   before('create environment', function (done) {


### PR DESCRIPTION
This PR 
- adds a new --es6 flag to enable ES6 (ES2015) syntax
- replaces `const` with `var` if --es6 is set
- adds string templates if --es6 is set
- prefers arrow functions for callbacks if --es6 is set
- makes sure that this feature is only available for Node.js >= 6.0.0
- adds tests for --es6

Reference Link https://github.com/expressjs/generator/issues/167