### PR TITLE
Remove jade

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This generator can also be further configured with the following command line fl
         --pug            add pug engine support
         --hbs            add handlebars engine support
     -H, --hogan          add hogan.js engine support
-    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
+    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|pug|twig|vash) (defaults to pug)
         --no-view        use static html instead of view engine
     -c, --css <engine>   add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git            add .gitignore

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -52,7 +52,7 @@ program
   .option('    --pug', 'add pug engine support', renamedOption('--pug', '--view=pug'))
   .option('    --hbs', 'add handlebars engine support', renamedOption('--hbs', '--view=hbs'))
   .option('-H, --hogan', 'add hogan.js engine support', renamedOption('--hogan', '--view=hogan'))
-  .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)')
+  .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|pug|twig|vash) (defaults to pug)')
   .option('    --no-view', 'use static html instead of view engine')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
@@ -226,9 +226,6 @@ function createApplication (name, dir) {
       case 'hjs':
         copyTemplateMulti('views', dir + '/views', '*.hjs')
         break
-      case 'jade':
-        copyTemplateMulti('views', dir + '/views', '*.jade')
-        break
       case 'pug':
         copyTemplateMulti('views', dir + '/views', '*.pug')
         break
@@ -298,13 +295,9 @@ function createApplication (name, dir) {
       app.locals.view = { engine: 'hjs' }
       pkg.dependencies.hjs = '~0.0.6'
       break
-    case 'jade':
-      app.locals.view = { engine: 'jade' }
-      pkg.dependencies.jade = '~1.11.0'
-      break
     case 'pug':
       app.locals.view = { engine: 'pug' }
-      pkg.dependencies.pug = '2.0.0-beta11'
+      pkg.dependencies.pug = '~2.0.3'
       break
     case 'twig':
       app.locals.view = { engine: 'twig' }
@@ -461,9 +454,9 @@ function main () {
 
   // Default view engine
   if (program.view === true) {
-    warning('the default view engine will not be jade in future releases\n' +
-      "use `--view=jade' or `--help' for additional options")
-    program.view = 'jade'
+    warning('no view was specifed the default view engine pug was used\n' +
+      "use `--view=' or `--help' for additional options")
+    program.view = 'pug'
   }
 
   // Generate application

--- a/templates/views/error.jade
+++ b/templates/views/error.jade
@@ -1,6 +1,0 @@
-extends layout
-
-block content
-  h1= message
-  h2= error.status
-  pre #{error.stack}

--- a/templates/views/index.jade
+++ b/templates/views/index.jade
@@ -1,5 +1,0 @@
-extends layout
-
-block content
-  h1= title
-  p Welcome to #{title}

--- a/templates/views/layout.jade
+++ b/templates/views/layout.jade
@@ -1,7 +1,0 @@
-doctype html
-html
-  head
-    title= title
-    link(rel='stylesheet', href='/stylesheets/style.css')
-  body
-    block content

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -38,8 +38,8 @@ describe('express(1)', function () {
       })
     })
 
-    it('should print jade view warning', function () {
-      assert.equal(ctx.stderr, "\n  warning: the default view engine will not be jade in future releases\n  warning: use `--view=jade' or `--help' for additional options\n\n")
+    it('should print no view warning', function () {
+      assert.equal(ctx.stderr, "\n  warning: no view was specifed the default view engine pug was used\n  warning: use `--view=' or `--help' for additional options\n\n")
     })
 
     it('should provide debug instructions', function () {
@@ -52,10 +52,10 @@ describe('express(1)', function () {
       assert.notEqual(ctx.files.indexOf('package.json'), -1)
     })
 
-    it('should have jade templates', function () {
-      assert.notEqual(ctx.files.indexOf('views/error.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('views/index.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('views/layout.jade'), -1)
+    it('should have pug templates', function () {
+      assert.notEqual(ctx.files.indexOf('views/error.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/index.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/layout.pug'), -1)
     })
 
     it('should have a package.json file', function () {
@@ -73,8 +73,8 @@ describe('express(1)', function () {
         '    "debug": "~2.6.9",\n' +
         '    "express": "~4.16.0",\n' +
         '    "http-errors": "~1.6.2",\n' +
-        '    "jade": "~1.11.0",\n' +
-        '    "morgan": "~1.9.0"\n' +
+        '    "morgan": "~1.9.0",\n' +
+        '    "pug": "~2.0.3"\n' +
         '  }\n' +
         '}\n')
     })
@@ -223,10 +223,10 @@ describe('express(1)', function () {
       assert.notEqual(ctx.files.indexOf('foo/package.json'), -1)
     })
 
-    it('should have jade templates', function () {
-      assert.notEqual(ctx.files.indexOf('foo/views/error.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('foo/views/index.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('foo/views/layout.jade'), -1)
+    it('should have pug templates', function () {
+      assert.notEqual(ctx.files.indexOf('foo/views/error.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('foo/views/index.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('foo/views/layout.pug'), -1)
     })
   })
 
@@ -420,10 +420,10 @@ describe('express(1)', function () {
       assert.notEqual(ctx.files.indexOf('.gitignore'), -1, 'should have .gitignore file')
     })
 
-    it('should have jade templates', function () {
-      assert.notEqual(ctx.files.indexOf('views/error.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('views/index.jade'), -1)
-      assert.notEqual(ctx.files.indexOf('views/layout.jade'), -1)
+    it('should have pug templates', function () {
+      assert.notEqual(ctx.files.indexOf('views/error.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/index.pug'), -1)
+      assert.notEqual(ctx.files.indexOf('views/layout.pug'), -1)
     })
   })
 


### PR DESCRIPTION
It appears that jade has some security vulnerabilities showing up in npm audit. Unfortunately jade has been deprecated and the project has been renamed as pug so to remediate these vulnerabilities we would need to remove jade from the project and default to pug. This PR does that, removes jade from the templates and and replaces the default view engine with pug. Since pug is just a renamed version of jade that is still being supported the impact is minimal.  