### PR TITLE
Jade to Pug

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ This generator can also be further configured with the following command line fl
 
         --version        output the version number
     -e, --ejs            add ejs engine support
-        --pug            add pug engine support
         --hbs            add handlebars engine support
     -H, --hogan          add hogan.js engine support
-    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
+        --jade           add jade engine support
+    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to pug)
         --no-view        use static html instead of view engine
     -c, --css <engine>   add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git            add .gitignore

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -49,10 +49,10 @@ program
   .version(VERSION, '    --version')
   .usage('[options] [dir]')
   .option('-e, --ejs', 'add ejs engine support', renamedOption('--ejs', '--view=ejs'))
-  .option('    --pug', 'add pug engine support', renamedOption('--pug', '--view=pug'))
   .option('    --hbs', 'add handlebars engine support', renamedOption('--hbs', '--view=hbs'))
   .option('-H, --hogan', 'add hogan.js engine support', renamedOption('--hogan', '--view=hogan'))
-  .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)')
+  .option('    --jade', 'add jade engine support', renamedOption('--jade', '--view=jade'))
+  .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to pug)')
   .option('    --no-view', 'use static html instead of view engine')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
@@ -304,7 +304,7 @@ function createApplication (name, dir) {
       break
     case 'pug':
       app.locals.view = { engine: 'pug' }
-      pkg.dependencies.pug = '2.0.0-beta11'
+      pkg.dependencies.pug = '~2.0.3'
       break
     case 'twig':
       app.locals.view = { engine: 'twig' }
@@ -456,14 +456,12 @@ function main () {
     if (program.ejs) program.view = 'ejs'
     if (program.hbs) program.view = 'hbs'
     if (program.hogan) program.view = 'hjs'
-    if (program.pug) program.view = 'pug'
+    if (program.jade) program.view = 'jade'
   }
 
   // Default view engine
   if (program.view === true) {
-    warning('the default view engine will not be jade in future releases\n' +
-      "use `--view=jade' or `--help' for additional options")
-    program.view = 'jade'
+    program.view = 'pug'
   }
 
   // Generate application


### PR DESCRIPTION
### Related Issue
#141 

### Description
Jade has already changed to Pug.
So we must change Jade to Pug.
See [https://www.npmjs.com/package/jade](https://www.npmjs.com/package/jade)
This pull request will change default view Jade to Pug.