### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "2.15.1",
-    "ejs": "2.6.1",
+    "ejs": "2.7.2",
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",
     "sorted-object": "2.0.1"


### PR DESCRIPTION
ejs 2.6.1 has reported issues with accessing passed arguments, should be updated to 2.7.2