### PR TITLE
remove unsupported Node.js, bump major, update pug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "1.8"
-  - "2.5"
-  - "3.3"
-  - "4.9"
-  - "5.12"
-  - "6.16"
-  - "7.10"
-  - "8.15"
-  - "9.11"
+  - "8"
+  - "10"
+  - "12"
+  - "13"
 matrix:
   fast_finish: true
 sudo: false
@@ -22,33 +15,6 @@ before_install:
   - |
     # Skip updating shrinkwrap / lock
     npm config set shrinkwrap false
-  # Setup Node.js version-specific dependencies
-  - |
-    # eslint for linting
-    # - remove on Node.js < 6
-    if [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -lt 6 ]]; then
-      node -pe 'Object.keys(require("./package").devDependencies).join("\n")' | \
-        grep -E '^eslint(-|$)' | \
-        xargs npm rm --save-dev
-    fi
-  - |
-    # mocha for testing
-    # - use 3.x for Node.js < 4
-    # - use 5.x for Node.js < 6
-    if [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -lt 4 ]]; then
-      npm install --save-dev mocha@3.5.3
-    elif [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -lt 6 ]]; then
-      npm install --save-dev mocha@5.2.0
-    fi
-  - |
-    # supertest for http calls
-    # - use 2.0.0 for Node.js < 4
-    # - use 3.4.2 for Node.js < 6
-    if [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -lt 4 ]]; then
-      npm install --save-dev supertest@2.0.0
-    elif [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -lt 6 ]]; then
-      npm install --save-dev supertest@3.4.2
-    fi
   # Update Node.js modules
   - |
     # Prune and rebuild node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,9 @@
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
-    - nodejs_version: "1.8"
-    - nodejs_version: "2.5"
-    - nodejs_version: "3.3"
-    - nodejs_version: "4.9"
-    - nodejs_version: "5.12"
-    - nodejs_version: "6.16"
-    - nodejs_version: "7.10"
-    - nodejs_version: "8.15"
-    - nodejs_version: "9.11"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+    - nodejs_version: "12"
+    - nodejs_version: "13"
 cache:
   - node_modules
 install:
@@ -29,24 +22,6 @@ install:
         sls "^eslint(-|$)" | `
         %{ npm rm --silent --save-dev $_ }
   # Setup Node.js version-specific dependencies
-  - ps: |
-      # mocha for testing
-      # - use 3.x for Node.js < 4
-      # - use 5.x for Node.js < 6
-      if ([int]$env:nodejs_version.split(".")[0] -lt 4) {
-        npm install --silent --save-dev mocha@3.5.3
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 6) {
-        npm install --silent --save-dev mocha@5.2.0
-      }
-  - ps: |
-      # supertest for http calls
-      # - use 2.0.0 for Node.js < 4
-      # - use 3.4.2 for Node.js < 6
-      if ([int]$env:nodejs_version.split(".")[0] -lt 4) {
-        npm install --silent --save-dev supertest@2.0.0
-      } elseif ([int]$env:nodejs_version.split(".")[0] -lt 6) {
-        npm install --silent --save-dev supertest@3.4.2
-      }
   # Update Node.js modules
   - ps: |
       # Prune & rebuild node_modules

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -304,7 +304,7 @@ function createApplication (name, dir) {
       break
     case 'pug':
       app.locals.view = { engine: 'pug' }
-      pkg.dependencies.pug = '2.0.0-beta11'
+      pkg.dependencies.pug = '~2.0.4'
       break
     case 'twig':
       app.locals.view = { engine: 'twig' }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-generator",
   "description": "Express' application generator",
-  "version": "4.16.1",
+  "version": "5.0.0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Aaron Heckmann <aaron.heckmann+github@gmail.com>",


### PR DESCRIPTION
    gen: update pug to ~2.0.4
    
    Fixes:
    - https://npmjs.com/advisories/785
    - Dependency on pug's -beta11


    build: add Node.js 10, 12, 13, remove EOL Node.js
    
    Bumps the package version since dropping support for Node.js versions is
    semver-major.
    
    Anyone who is still generating new express apps for out-of-support
    Node.js versions (unadvisedly) can either modify the generated
    dependencies after generation, or use express-generator 4.x
