### PR TITLE
Default project structure tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,31 @@ Start your Express.js app at `http://localhost:3000/`:
 $ npm start
 ```
 
+## Project Structure
+
+The generator creates the following project structure by default:
+
+```
+.
+├── app.js
+├── bin
+│   └── www
+├── package-lock.json
+├── package.json
+├── public
+│   ├── images
+│   ├── javascripts
+│   └── stylesheets
+│       └── style.css
+├── routes
+│   ├── index.js
+│   └── users.js
+└── views
+    ├── error.jade
+    ├── index.jade
+    └── layout.jade
+```
+
 ## Command Line Options
 
 This generator can also be further configured with the following command line flags.


### PR DESCRIPTION
Adds default project structure to readme

Open to suggestions here. Definitely I think that there should be some explanation about the structure, but as it stands just adding this to the readme (IMO) improves the project because it stands to document things as they currently are.

This is in reference to https://github.com/expressjs/generator/issues/62, where I think we can continue to talk about documenting the structure.