### PR TITLE
Adds SIGTERM listener to gracefully shutdown the server

### DIFF
--- a/templates/js/www.ejs
+++ b/templates/js/www.ejs
@@ -88,3 +88,10 @@ function onListening() {
     : 'port ' + addr.port;
   debug('Listening on ' + bind);
 }
+
+process.on('SIGTERM', () => {
+    debug('SIGTERM signal received: closing server');
+    server.close(() => {
+        debug('Http server closed');
+    });
+});


### PR DESCRIPTION
Kubernetes and other process managers send a SIGTERM to applications to give them time to shut down. This change adds a listener to this event which shuts the server down gracefully.