### PR TITLE
Adding JSX (React) as an option for the view engine in express

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This generator can also be further configured with the following command line fl
         --pug            add pug engine support
         --hbs            add handlebars engine support
     -H, --hogan          add hogan.js engine support
-    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
+    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash|jsx) (defaults to jade)
         --no-view        use static html instead of view engine
     -c, --css <engine>   add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
         --git            add .gitignore

--- a/bin/express-cli.js
+++ b/bin/express-cli.js
@@ -52,7 +52,7 @@ program
   .option('    --pug', 'add pug engine support', renamedOption('--pug', '--view=pug'))
   .option('    --hbs', 'add handlebars engine support', renamedOption('--hbs', '--view=hbs'))
   .option('-H, --hogan', 'add hogan.js engine support', renamedOption('--hogan', '--view=hogan'))
-  .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)')
+  .option('-v, --view <engine>', 'add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash|jsx) (defaults to jade)')
   .option('    --no-view', 'use static html instead of view engine')
   .option('-c, --css <engine>', 'add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)')
   .option('    --git', 'add .gitignore')
@@ -238,6 +238,9 @@ function createApplication (name, dir) {
       case 'vash':
         copyTemplateMulti('views', dir + '/views', '*.vash')
         break
+      case 'jsx':
+        copyTemplateMulti('views', dir + '/views', '*.jsx')
+        break
     }
   } else {
     // Copy extra public files
@@ -313,6 +316,15 @@ function createApplication (name, dir) {
     case 'vash':
       app.locals.view = { engine: 'vash' }
       pkg.dependencies.vash = '~0.12.6'
+      break
+    case 'jsx':
+      app.locals.view = {
+        engine: 'jsx',
+        render: "require('express-react-views').createEngine()"
+      }
+      pkg.dependencies['express-react-views'] = '^0.11.0'
+      pkg.dependencies.react = '^16.13.1'
+      pkg.dependencies['react-dom'] = '^16.13.1'
       break
     default:
       app.locals.view = false

--- a/templates/views/error.jsx
+++ b/templates/views/error.jsx
@@ -1,0 +1,14 @@
+var React = require('react');
+var Layout = require('./layout');
+
+function Index(props) {
+  return (
+    <Layout>
+      <h1>{props.message}</h1>
+      <h2>{props.error.status}</h2>
+      <pre>{props.error.stack}</pre>
+    </Layout>
+  );
+}
+
+module.exports = Index;

--- a/templates/views/index.jsx
+++ b/templates/views/index.jsx
@@ -1,0 +1,13 @@
+var React = require('react');
+var Layout = require('./layout');
+
+function Index(props) {
+  return (
+    <Layout title={props.title}>
+      <h1>{props.title}</h1>
+      <p>Welcome to {props.title}</p>
+    </Layout>
+  );
+}
+
+module.exports = Index;

--- a/templates/views/layout.jsx
+++ b/templates/views/layout.jsx
@@ -1,0 +1,14 @@
+var React = require('react');
+
+function Layout(props) {
+  return (
+    <html>
+      <head>
+        <title>{props.title}</title>
+      </head>
+      <body>{props.children}</body>
+    </html>
+  );
+}
+
+module.exports = Layout;


### PR DESCRIPTION
The Express official docs list react as an option for the view engine using the express-react-views module.
This pull request adds jsx as an option for the view engine from the CLI using --view = jsx.

Commits have been made for -

1. Adding CLI support for jsx.
2. Default jsx templates
3. Tests to validate its working.
4. Updated README to include jsx
