### PR TITLE
feat: build and run from Docker Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,41 @@ This generator can also be further configured with the following command line fl
     -f, --force          force on non-empty directory
     -h, --help           output usage information
 
+## Using Docker
+
+Download the Dockerfile:
+
+```bash
+mkdir docker
+cd docker
+wget https://github.com/expressjs/generator/raw/master/docker/Dockerfile
+```
+
+Build the Docker images:
+
+```bash
+docker build -t expressjs-generator:latest .
+```
+
+Make a folder where you want to generate the Service:
+
+```bash
+mkdir service
+cd service
+```
+
+Run the generator from image to generate service:
+
+```bash
+docker run -it --rm -v $PWD:/home/expressjs/app expressjs-generator
+```
+
+Run and attach interactive shell to the generator docker container to work from inside the running container:
+
+```bash
+docker run -it --rm -v $PWD:/home/expressjs/app expressjs-generator /bin/bash
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:20.04
+RUN \
+  # configure the "expressjs" user
+  groupadd expressjs && \
+  useradd expressjs -s /bin/bash -m -g expressjs -G sudo && \
+  echo 'expressjs:expressjs' |chpasswd && \
+  mkdir /home/expressjs/app && \
+  export DEBIAN_FRONTEND=noninteractive && \
+  export TZ=Europe\Paris && \
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+  apt-get update && \
+  # install utilities
+  apt-get install -y \
+    wget \
+    sudo && \
+  # install node.js
+  wget https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.gz -O /tmp/node.tar.gz && \
+  tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
+  # cleanup
+  apt-get clean && \
+  rm -rf \
+    /home/expressjs/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# install expressjs-generator
+
+RUN \
+  # install the blueprint
+  npm install -g express-generator && \
+  # fix expressjs user permissions
+  chown -R expressjs:expressjs \
+    /home/expressjs \
+    /usr/local/lib/node_modules && \
+  # cleanup
+  rm -rf \
+    /home/expressjs/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# expose the working directory
+USER expressjs
+ENV PATH $PATH:/usr/bin
+WORKDIR "/home/expressjs/app"
+VOLUME ["/home/expressjs/app"]
+CMD ["express"]


### PR DESCRIPTION
Build and run the generator from docker image support added.

The main aim and motivation behind doing this is, because
of a no. of different generator are there,
which are compatible and works with the different version of generator
and also might be incompatible with other generator or versions of generator

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>