### PR TITLE
Add renovate bot for deps in package json and scaffolded template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,14 @@
 {
-  "extends": [
-    "config:base"
+  "extends": ["config:base"],
+  "regexManagers": [
+    {
+      "fileMatch": ["^bin/[^\\.]+\\.js$"],
+      "matchStrings": [
+        "pkg\\.dependencies\\[[\"|'](?<depName>.*?)[\"|']\\]\\s*=\\s*[\"|'](?<currentValue>.*?)[\"|']",
+        "pkg\\.dependencies\\.(?<depName>.*?)\\s*=\\s*[\"|'](?<currentValue>.*?)[\"|']"
+
+      ],
+      "datasourceTemplate": "npm"
+    }
   ]
 }


### PR DESCRIPTION
# Description
- Added `renovate.json` file to configure [Renovate Bot](https://docs.renovatebot.com/)
- Added extra RegEx to bump versions of dependencies in all `bin/*.js` files

# Context
Fix #298 

⚠️ This needs to install [Renovate Bot GitHub App](https://github.com/apps/renovate).

# How has been tested?
You can see an example working in my fork: https://github.com/oscard0m/generator/commits/master

# Resources
* https://docs.renovatebot.com/setup-azure-devops/#create-a-configjs-file