### PR TITLE
Error handler should include "title" parameter

### DIFF
--- a/templates/js/app.js.ejs
+++ b/templates/js/app.js.ejs
@@ -44,7 +44,7 @@ app.use(function(err, req, res, next) {
 
   // render the error page
   res.status(err.status || 500);
-  res.render('error');
+  res.render('error', { title: 'Express' });
 });
 
 <% } -%>


### PR DESCRIPTION
Because the template "error.jade" extends "layout.jade", which requires the "title" parameter. 
jade engine would complain without this when it is trying to render the error page.